### PR TITLE
Extracted domain specifications from the business plugin

### DIFF
--- a/core/src/main/java/org/seedstack/business/internal/identity/IdentityPlugin.java
+++ b/core/src/main/java/org/seedstack/business/internal/identity/IdentityPlugin.java
@@ -12,21 +12,18 @@
  */
 package org.seedstack.business.internal.identity;
 
-import org.seedstack.business.api.domain.identity.IdentityHandler;
 import io.nuun.kernel.api.Plugin;
 import io.nuun.kernel.api.plugin.InitState;
 import io.nuun.kernel.api.plugin.context.InitContext;
 import io.nuun.kernel.api.plugin.request.ClasspathScanRequest;
 import io.nuun.kernel.core.AbstractPlugin;
 import org.kametic.specifications.Specification;
+import org.seedstack.business.api.domain.meta.specifications.DomainSpecifications;
 import org.seedstack.seed.core.internal.application.ApplicationPlugin;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Map;
-
-import static org.seedstack.business.api.domain.meta.specifications.DomainSpecifications.classIsAbstract;
-import static org.seedstack.business.api.domain.meta.specifications.DomainSpecifications.classIsInterface;
 
 /**
  * Plugin used for identity management, scan all classes that implements IdentityHandler
@@ -34,9 +31,6 @@ import static org.seedstack.business.api.domain.meta.specifications.DomainSpecif
  * @author redouane.loulou@ext.mpsa.com
  */
 public class IdentityPlugin extends AbstractPlugin {
-
-    @SuppressWarnings("unchecked")
-	private final Specification<Class<?>> IdentityHandlerSpecs = and(not(classIsInterface()), not(classIsAbstract()), descendantOf(IdentityHandler.class));
 
     private Collection<Class<?>> identityHandlerClasses;
 
@@ -49,13 +43,13 @@ public class IdentityPlugin extends AbstractPlugin {
 	@SuppressWarnings("rawtypes")
 	public InitState init(InitContext initContext) {
 		Map<Specification, Collection<Class<?>>> scannedTypesBySpecification = initContext.scannedTypesBySpecification();
-		identityHandlerClasses = scannedTypesBySpecification.get(IdentityHandlerSpecs);
+		identityHandlerClasses = scannedTypesBySpecification.get(DomainSpecifications.identityHandlerSpecification);
 		return InitState.INITIALIZED;
 	}
 
 	@Override
 	public Collection<ClasspathScanRequest> classpathScanRequests() {
-		return classpathScanRequestBuilder().specification(IdentityHandlerSpecs).build();
+		return classpathScanRequestBuilder().specification(DomainSpecifications.identityHandlerSpecification).build();
 	}
 
 	@Override

--- a/core/src/test/java/org/seedstack/business/internal/BusinessCorePluginTest.java
+++ b/core/src/test/java/org/seedstack/business/internal/BusinessCorePluginTest.java
@@ -57,7 +57,7 @@ public class BusinessCorePluginTest {
 	
 	@Test
 	public void aggregateSpecification_works_fine () {
-		Assertions.assertThat(DomainSpecifications.aggregateSpecification().isSatisfiedBy(Discount.class)).isTrue();
+		Assertions.assertThat(DomainSpecifications.aggregateRootSpecification.isSatisfiedBy(Discount.class)).isTrue();
 	}
 
 }

--- a/jpa/src/main/java/org/seedstack/business/jpa/assertions/BusinessJpaReflectionAsserts.java
+++ b/jpa/src/main/java/org/seedstack/business/jpa/assertions/BusinessJpaReflectionAsserts.java
@@ -9,14 +9,14 @@
  */
 package org.seedstack.business.jpa.assertions;
 
+import org.apache.commons.collections.iterators.ArrayIterator;
+import org.kametic.specifications.AbstractSpecification;
+import org.kametic.specifications.Specification;
+import org.seedstack.business.api.domain.meta.specifications.BaseClassSpecifications;
 import org.seedstack.business.assertions.BusinessAssertionsErrorCodes;
 import org.seedstack.business.assertions.BusinessReflectionAsserts;
 import org.seedstack.business.core.domain.base.BaseFactory;
 import org.seedstack.business.jpa.infrastructure.repository.BaseJpaRepository;
-import org.apache.commons.collections.iterators.ArrayIterator;
-import org.seedstack.business.api.domain.meta.specifications.DomainSpecifications;
-import org.kametic.specifications.AbstractSpecification;
-import org.kametic.specifications.Specification;
 import org.seedstack.seed.core.api.ErrorCode;
 import org.seedstack.seed.core.api.SeedException;
 import org.slf4j.Logger;
@@ -45,7 +45,7 @@ public final class BusinessJpaReflectionAsserts {
 
         // we check that the class extends GenericJpaRepository
         $(
-                actual, DomainSpecifications.classInherits(BaseJpaRepository.class),
+                actual, BaseClassSpecifications.classInherits(BaseJpaRepository.class),
                 BusinessAssertionsErrorCodes.CLASS_MUST_EXTENDS,
                 PARENT_CLASS_NAME, BaseJpaRepository.class.getName(),
                 MORE, "Please do not forget to remove all methods already defined."
@@ -64,7 +64,7 @@ public final class BusinessJpaReflectionAsserts {
 
         // we check that the class extends GenericJpaRepository
         $(
-                actual, DomainSpecifications.classInherits(BaseFactory.class),
+                actual, BaseClassSpecifications.classInherits(BaseFactory.class),
                 BusinessAssertionsErrorCodes.CLASS_MUST_EXTENDS,
                 PARENT_CLASS_NAME, BaseFactory.class.getName(),
                 MORE, "Please do not forget to remove all methods already defined."

--- a/specs/pom.xml
+++ b/specs/pom.xml
@@ -46,5 +46,10 @@
             <artifactId>seed-unittest-support</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/specs/src/main/java/org/seedstack/business/api/domain/meta/specifications/BaseClassSpecifications.java
+++ b/specs/src/main/java/org/seedstack/business/api/domain/meta/specifications/BaseClassSpecifications.java
@@ -1,0 +1,456 @@
+/**
+ * Copyright (c) 2013-2015 by The SeedStack authors. All rights reserved.
+ *
+ * This file is part of SeedStack, An enterprise-oriented full development stack.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.seedstack.business.api.domain.meta.specifications;
+
+import org.apache.commons.lang.ArrayUtils;
+import org.codemonkey.javareflection.FieldUtils;
+import org.kametic.specifications.*;
+import org.kametic.specifications.reflect.ClassMethodsAnnotatedWith;
+import org.kametic.specifications.reflect.DescendantOfSpecification;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.*;
+
+/**
+ * @author Pierre Thirouin <pierre.thirouin@ext.mpsa.com>
+ */
+public class BaseClassSpecifications {
+
+    private static final Logger logger = LoggerFactory.getLogger(BaseClassSpecifications.class);
+
+    public static Specification<Class<?>> classIs(final Class<?> attendee) {
+        return new AbstractSpecification<Class<?>>() {
+
+            @Override
+            public boolean isSatisfiedBy(Class<?> candidate) {
+
+                return candidate != null && candidate.equals(attendee);
+            }
+
+        };
+    }
+
+    public static Specification<Class<?>> classAnnotatedWith(final Class<? extends Annotation> klass) {
+        return new AbstractSpecification<Class<?>>() {
+            @Override
+            public boolean isSatisfiedBy(Class<?> candidate) {
+                return candidate != null && candidate.getAnnotation(klass) != null;
+            }
+        };
+    }
+
+    public static Specification<Class<?>> descendantOf(Class<?> ancestor) {
+        return new DescendantOfSpecification(ancestor);
+    }
+
+    /**
+     * @param modifier the expected modifier
+     * @return a specification which checks the class modifier
+     */
+    public static Specification<Class<?>> classModifierIs(final int modifier) {
+        return new AbstractSpecification<Class<?>>() {
+            @Override
+            public boolean isSatisfiedBy(Class<?> candidate) {
+                return (candidate.getModifiers() & modifier) != 0;
+
+            }
+        };
+    }
+
+    /**
+     * @return a specification which check if a least one constructor is public
+     */
+    public static Specification<Class<?>> classConstructorIsPublic() {
+        return new AbstractSpecification<Class<?>>() {
+            @Override
+            public boolean isSatisfiedBy(Class<?> candidate) {
+
+                for (Constructor<?> constructor : candidate.getDeclaredConstructors()) {
+                    if (Modifier.isPublic(constructor.getModifiers())) {
+                        return true;
+                    }
+                }
+                return false;
+            }
+        };
+    }
+
+    /**
+     * @param classes the list of class to check
+     * @return a specification which check if classes contain the candidate class
+     */
+    public static Specification<Class<?>> classIsIn(final Collection<Class<?>> classes) {
+        return new AbstractSpecification<Class<?>>() {
+            @Override
+            public boolean isSatisfiedBy(Class<?> candidate) {
+                return candidate != null && classes != null && classes.contains(candidate);
+            }
+        };
+    }
+
+    /**
+     * @param interfaceClass the requested interface
+     * @return a specification which check if one candidate ancestor implements the given interface
+     */
+    public static Specification<Class<?>> ancestorImplements(final Class<?> interfaceClass) {
+        return new AbstractSpecification<Class<?>>() {
+
+            @Override
+            public boolean isSatisfiedBy(Class<?> candidate) {
+                if (candidate == null) {
+                    return false;
+                }
+
+                boolean result = false;
+
+                Class<?>[] allInterfacesAndClasses = getAllInterfacesAndClasses(candidate);
+
+                for (Class<?> clazz : allInterfacesAndClasses) {
+                    if (!clazz.isInterface()) {
+                        for (Class<?> i : clazz.getInterfaces()) {
+                            if (i.equals(interfaceClass)) {
+                                result = true;
+                                break;
+                            }
+                        }
+                    }
+                }
+
+                return result;
+            }
+
+        };
+    }
+
+    /**
+     * Checks if the candidate has one field annotated or meta annotated by the given annotation.
+     *
+     * @param annotationClass the requested annotation
+     * @return the specification
+     */
+    public static Specification<Class<?>> fieldDeepAnnotatedWith(final Class<? extends Annotation> annotationClass) {
+
+        return new AbstractSpecification<Class<?>>() {
+
+            @Override
+            public boolean isSatisfiedBy(Class<?> candidate) {
+                try {
+                    if (candidate != null) {
+                        do {
+                            for (Field field : candidate.getDeclaredFields()) {
+                                if (field.isAnnotationPresent(annotationClass)) {
+                                    return true;
+                                }
+                            }
+                            candidate = candidate.getSuperclass();
+                        } while (candidate != null && candidate != Object.class);
+                    }
+                } catch (Throwable error) {  // NOSONAR
+                    logger.trace(String.format("Warning in Specification fieldAnnotatedWith. Candidate: %s, annotation: %s", candidate.getSimpleName(), annotationClass.getSimpleName()), error);
+                }
+
+                return false;
+            }
+        };
+    }
+
+    /**
+     * Checks if the candidate inherits from the given class.
+     *
+     * @param klass the requested class
+     * @return the specification
+     */
+    public static Specification<Class<?>> classInherits(final Class<?> klass) {
+        return new AbstractSpecification<Class<?>>() {
+            @Override
+            public boolean isSatisfiedBy(Class<?> candidate) {
+                return candidate != null && klass.isAssignableFrom(candidate);
+            }
+        };
+    }
+
+    /**
+     * Checks if the candidate or an ancestor is annotated or meta annotated by the given annotation.
+     *
+     * @param anoKlass the requested annotation
+     * @return the specification
+     */
+    public static Specification<Class<?>> ancestorMetaAnnotatedWith(final Class<? extends Annotation> anoKlass) {
+        return new AbstractSpecification<Class<?>>() {
+            @Override
+            public boolean isSatisfiedBy(Class<?> candidate) {
+
+                if (candidate == null) {
+                    return false;
+                }
+
+                boolean result = false;
+
+                Class<?>[] allInterfacesAndClasses = getAllInterfacesAndClasses(candidate);
+
+                for (Class<?> clazz : allInterfacesAndClasses) {
+                    boolean satisfiedBy = classMetaAnnotatedWith(anoKlass).isSatisfiedBy(clazz);
+                    if (satisfiedBy) {
+                        result = true;
+                        break;
+                    }
+                }
+
+                return result;
+            }
+        };
+    }
+
+    /**
+     * Checks if the candidate is annotated or meta annotated by the given annotation.
+     *
+     * @param klass the requested annotation
+     * @return the specification
+     */
+    public static Specification<Class<?>> classMetaAnnotatedWith(final Class<? extends Annotation> klass) {
+        return new AbstractSpecification<Class<?>>() {
+            @Override
+            public boolean isSatisfiedBy(Class<?> candidate) {
+                return candidate != null && hasAnnotationDeep(candidate, klass);
+            }
+        };
+
+    }
+
+    /**
+     * Checks if the candidate has at least one setter.
+     *
+     * @return the specification
+     */
+    public static Specification<Class<?>> classHasSetters() {
+        return new AbstractSpecification<Class<?>>() {
+            @Override
+            public boolean isSatisfiedBy(Class<?> candidate) {
+                return candidate != null &&
+                        FieldUtils.collectFields(
+                                candidate, candidate,
+                                EnumSet.of(FieldUtils.Visibility.PUBLIC, FieldUtils.Visibility.PROTECTED, FieldUtils.Visibility.PRIVATE, FieldUtils.Visibility.DEFAULT),
+                                EnumSet.of(FieldUtils.BeanRestriction.YES_SETTER)).get(candidate)
+                                .isEmpty();
+            }
+        };
+    }
+
+    /**
+     * Checks if the candidate has only setters with the visibility package.
+     *
+     * @return the specification
+     */
+    public static Specification<Class<?>> classHasOnlyPackageViewSetters() {
+        return new AbstractSpecification<Class<?>>() {
+            @Override
+            public boolean isSatisfiedBy(Class<?> candidate) {
+                return candidate != null &&
+                        FieldUtils.collectFields(
+                                candidate, candidate,
+                                EnumSet.of(FieldUtils.Visibility.DEFAULT),
+                                EnumSet.of(FieldUtils.BeanRestriction.YES_SETTER)).get(candidate)
+                                .isEmpty() &&
+                        classHasSetters().isSatisfiedBy(candidate);
+            }
+        };
+    }
+
+    /**
+     * Checks if the given class is annotated or meta annotated with the given annotation.
+     *
+     * @param aClass          the class to check
+     * @param annotationClass the requested annotation
+     * @return true if the class if annotated or meta annotated, false otherwise
+     */
+    public static boolean hasAnnotationDeep(Class<?> aClass, Class<? extends Annotation> annotationClass) {
+        if (aClass.equals(annotationClass)) {
+            return true;
+        }
+
+        for (Annotation anno : aClass.getAnnotations()) {
+            Class<? extends Annotation> annoClass = anno.annotationType();
+            if (!annoClass.getPackage().getName().startsWith("java.lang")
+                    && hasAnnotationDeep(annoClass, annotationClass)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Checks if the candidate is an interface.
+     *
+     * @return the specification
+     */
+    public static Specification<Class<?>> classIsInterface() {
+        return new AbstractSpecification<Class<?>>() {
+            @Override
+            public boolean isSatisfiedBy(Class<?> candidate) {
+
+                return candidate != null && candidate.isInterface();
+            }
+        };
+    }
+
+    /**
+     * Checks if the candidate equals to the given class.
+     *
+     * @param notCandidate the class to check
+     * @return the specification
+     */
+    public static Specification<Class<?>> classIsNot(final Class<?> notCandidate) {
+        return new AbstractSpecification<Class<?>>() {
+            @Override
+            public boolean isSatisfiedBy(Class<?> candidate) {
+
+                return candidate != null && !candidate.equals(notCandidate);
+            }
+        };
+    }
+
+    /**
+     * Checks if the candidate has interface.
+     *
+     * @return the specification
+     */
+    public static Specification<Class<?>> classHasSuperInterfaces() {
+        return new AbstractSpecification<Class<?>>() {
+            @Override
+            public boolean isSatisfiedBy(Class<?> candidate) {
+                Class<?>[] interfaces = {};
+                if (candidate != null) {
+                    interfaces = candidate.getInterfaces();
+                }
+                return candidate != null && interfaces != null && interfaces.length > 0;
+            }
+        };
+    }
+
+    /**
+     * Checks if the class is an annotation
+     *
+     * @return the specification
+     */
+    public static Specification<Class<?>> classIsAnnotation() {
+        return new AbstractSpecification<Class<?>>() {
+            @Override
+            public boolean isSatisfiedBy(Class<?> candidate) {
+
+                return candidate != null && candidate.isAnnotation();
+            }
+        };
+    }
+
+    /**
+     * Checks if the class is abstract.
+     *
+     * @return the specification
+     */
+    public static Specification<Class<?>> classIsAbstract() {
+        return new AbstractSpecification<Class<?>>() {
+            @Override
+            public boolean isSatisfiedBy(Class<?> candidate) {
+
+                return candidate != null && Modifier.isAbstract(candidate.getModifiers());
+            }
+        };
+    }
+
+    /**
+     * Checks if at least one method of the class is annotated with the annotation class.
+     *
+     * @param annotationClass the requested annotation
+     * @return the specification
+     */
+    public static Specification<Class<?>> methodAnnotatedWith(final Class<? extends Annotation> annotationClass) {
+        return new ClassMethodsAnnotatedWith(annotationClass);
+    }
+
+    static Class<?>[] getAllInterfacesAndClasses(Class<?> clazz) {
+        return getAllInterfacesAndClasses(new Class[]{clazz});
+    }
+
+    /**
+     * This method walks up the inheritance hierarchy to make sure we get every class/interface/superclass/interface's superclass that could
+     * possibly contain the declaration of the annotated method we're looking for.
+     *
+     * @param classes array of class
+     * @return array of class
+     */
+    @SuppressWarnings("unchecked")
+    static Class<?>[] getAllInterfacesAndClasses(Class<?>[] classes) {
+        if (0 == classes.length) {
+            return classes;
+        } else {
+            List<Class<?>> extendedClasses = new ArrayList<Class<?>>();
+            // all interfaces hierarchy
+            for (Class<?> clazz : classes) {
+                if (clazz != null) {
+                    Class<?>[] interfaces = clazz.getInterfaces();
+                    if (interfaces != null) {
+                        extendedClasses
+                                .addAll(Arrays
+                                        .asList(interfaces));
+                    }
+                    Class<?> superclass = clazz.getSuperclass();
+                    if (superclass != null && superclass != Object.class) {
+                        extendedClasses
+                                .addAll(Arrays
+                                        .asList(superclass));
+                    }
+                }
+            }
+
+            // Class::getInterfaces() gets only interfaces/classes
+            // implemented/extended directly by a given class.
+            // We need to walk the whole way up the tree.
+            return (Class[]) ArrayUtils.addAll(classes,
+                    getAllInterfacesAndClasses(extendedClasses
+                            .toArray(new Class[extendedClasses.size()])));
+        }
+    }
+
+    /**
+     * Logical OR between the specifications.
+     *
+     * @param participants array of specification
+     * @return the specification
+     */
+    public static Specification<Class<?>> or(Specification<Class<?>>... participants) {
+        return new OrSpecification<Class<?>>(participants);
+    }
+
+    /**
+     * Logical AND between the specifications.
+     *
+     * @param participants array of specification
+     * @return the specification
+     */
+    public static Specification<Class<?>> and(Specification<Class<?>>... participants) {
+        return new AndSpecification<Class<?>>(participants);
+    }
+
+    /**
+     * The negation of the given specification
+     *
+     * @param participant the specification
+     * @return the specification
+     */
+    public static Specification<Class<?>> not(Specification<Class<?>> participant) {
+        return new NotSpecification<Class<?>>(participant);
+    }
+}

--- a/specs/src/main/java/org/seedstack/business/api/domain/meta/specifications/DomainSpecifications.java
+++ b/specs/src/main/java/org/seedstack/business/api/domain/meta/specifications/DomainSpecifications.java
@@ -9,455 +9,116 @@
  */
 package org.seedstack.business.api.domain.meta.specifications;
 
-import org.seedstack.business.api.domain.annotations.DomainAggregateRoot;
-import org.seedstack.business.api.domain.annotations.DomainEntity;
-import org.seedstack.business.api.domain.annotations.DomainValueObject;
-import org.apache.commons.lang.ArrayUtils;
-import org.codemonkey.javareflection.FieldUtils;
-import org.codemonkey.javareflection.FieldUtils.BeanRestriction;
-import org.codemonkey.javareflection.FieldUtils.Visibility;
-import org.kametic.specifications.*;
-import org.kametic.specifications.reflect.ClassMethodsAnnotatedWith;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.kametic.specifications.Specification;
+import org.seedstack.business.api.application.GenericApplicationService;
+import org.seedstack.business.api.application.annotations.ApplicationService;
+import org.seedstack.business.api.domain.GenericDomainPolicy;
+import org.seedstack.business.api.domain.GenericDomainService;
+import org.seedstack.business.api.domain.annotations.*;
+import org.seedstack.business.api.domain.identity.IdentityHandler;
+import org.seedstack.business.api.interfaces.GenericInterfacesService;
+import org.seedstack.business.api.interfaces.annotations.InterfacesService;
+import org.seedstack.business.api.interfaces.assembler.Assembler;
+import org.seedstack.business.api.interfaces.assembler.DtoOf;
+import org.seedstack.business.api.interfaces.query.finder.Finder;
 
-import java.lang.annotation.Annotation;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
-import java.util.*;
+import static org.seedstack.business.api.domain.meta.specifications.BaseClassSpecifications.*;
 
 /**
  * This class provides helper methods for domain specifications.
  *
  * @author epo.jemba@ext.mpsa.com
  */
+@SuppressWarnings("unchecked")
 public final class DomainSpecifications {
-
-    private static final Logger logger = LoggerFactory.getLogger(DomainSpecifications.class);
 
     private DomainSpecifications() {
     }
 
     /**
-     * @return specification for aggregate root.
+     * The aggregate root specification.
      */
-    public static Specification<Class<?>> aggregateSpecification() {
-        return and(
+    public static final Specification<Class<?>> aggregateRootSpecification = and(
                 ancestorMetaAnnotatedWith(DomainAggregateRoot.class),
                 not(classIsAbstract()),
                 not(classIsInterface())
         );
-    }
 
     /**
-     * @return a specification for domain entities.
+     * The domain entities specification.
      */
-    public static Specification<Class<?>> entitySpecification() {
-        return and(
+    public static final Specification<Class<?>> entitySpecification = and(
                 ancestorMetaAnnotatedWith(DomainEntity.class),
                 not(classIsAbstract()),
                 not(classIsInterface())
         );
-    }
 
     /**
-     * @return a specification for domain value objects.
+     * The domain value objects specification.
      */
-    public static Specification<Class<?>> valueObjectSpecification() {
-        return and(
+    public static final Specification<Class<?>> valueObjectSpecification = and(
                 ancestorMetaAnnotatedWith(DomainValueObject.class),
                 not(classIsAbstract()),
                 not(classIsInterface())
         );
-    }
 
-    /**
-     * @param modifier the expected modifier
-     * @return a specification which checks the class modifier
-     */
-    public static Specification<Class<?>> classModifierIs(final int modifier) {
-        return new AbstractSpecification<Class<?>>() {
-            @Override
-            public boolean isSatisfiedBy(Class<?> candidate) {
-                return (candidate.getModifiers() & modifier) != 0;
+    public static final Specification<Class<?>> domainRepoSpecification = and(
+                ancestorMetaAnnotatedWith(DomainRepository.class),
+                classIsInterface(),
+                not(classIsAnnotation())
+        );
 
-            }
-        };
-    }
+    public static final Specification<Class<?>> domainServiceSpecification = and(
+                ancestorMetaAnnotatedWith(DomainService.class),
+                classIsInterface(),
+                not(classIsAnnotation()),
+                not(classIs(GenericDomainService.class)));
 
-    /**
-     * @return a specification which check if a least one constructor is public
-     */
-    public static Specification<Class<?>> classConstructorIsPublic() {
-        return new AbstractSpecification<Class<?>>() {
-            @Override
-            public boolean isSatisfiedBy(Class<?> candidate) {
+    public static final Specification<Class<?>> applicationServiceSpecification = and(
+                ancestorMetaAnnotatedWith(ApplicationService.class),
+                classIsInterface(),
+                not(classIsAnnotation()),
+                not(classIs(GenericApplicationService.class)));
 
-                for (Constructor<?> constructor : candidate.getDeclaredConstructors()) {
-                    if (Modifier.isPublic(constructor.getModifiers())) {
-                        return true;
-                    }
-                }
-                return false;
-            }
-        };
-    }
+    public static final Specification<Class<?>> finderServiceSpecification = and(
+                ancestorMetaAnnotatedWith(Finder.class),
+                classIsInterface(),
+                not(classIsAnnotation()));
 
-    /**
-     * @param classes the list of class to check
-     * @return a specification which check if classes contain the candidate class
-     */
-    public static Specification<Class<?>> classIsIn(final Collection<Class<?>> classes) {
-        return new AbstractSpecification<Class<?>>() {
-            @Override
-            public boolean isSatisfiedBy(Class<?> candidate) {
-                return candidate != null && classes != null && classes.contains(candidate);
-            }
-        };
-    }
+    public static final Specification<Class<?>> policySpecification = and(
+                ancestorMetaAnnotatedWith(DomainPolicy.class),
+                classIsInterface(),
+                not(classIsAnnotation()),
+                not(classIs(GenericDomainPolicy.class)));
 
-    /**
-     * @param interfaceClass the requested interface
-     * @return a specification which check if one candidate ancestor implements the given interface
-     */
-    public static Specification<Class<?>> ancestorImplements(final Class<?> interfaceClass) {
-        return new AbstractSpecification<Class<?>>() {
+    public static final Specification<Class<?>> interfacesServiceSpecification = and(
+                ancestorMetaAnnotatedWith(InterfacesService.class),
+                classIsInterface(),
+                not(classIsAnnotation()),
+                not(classIs(GenericInterfacesService.class)));
 
-            @Override
-            public boolean isSatisfiedBy(Class<?> candidate) {
-                if (candidate == null) {
-                    return false;
-                }
+    public static final Specification<Class<?>> domainFactorySpecification = and(
+                ancestorMetaAnnotatedWith(DomainFactory.class),
+                classIsInterface(),
+                not(classIsAnnotation()));
 
-                boolean result = false;
+    public static final Specification<Class<?>> assemblerSpecification = and(
+                not(classIsInterface()),
+                not(classIsAbstract()),
+                descendantOf(Assembler.class));
 
-                Class<?>[] allInterfacesAndClasses = getAllInterfacesAndClasses(candidate);
+    public static final Specification<Class<?>> domainRepoImplSpecification = and(
+                classAnnotatedWith(DomainRepositoryImpl.class),
+                not(classIsInterface()),
+                not(classIsAbstract()),
+                not(classIsAnnotation()));
 
-                for (Class<?> clazz : allInterfacesAndClasses) {
-                    if (!clazz.isInterface()) {
-                        for (Class<?> i : clazz.getInterfaces()) {
-                            if (i.equals(interfaceClass)) {
-                                result = true;
-                                break;
-                            }
-                        }
-                    }
-                }
+    public static final Specification<Class<?>> dtoWithDefaultAssemblerSpecification = and(
+                classAnnotatedWith(DtoOf.class));
 
-                return result;
-            }
-
-        };
-    }
-
-    /**
-     * Checks if the candidate has one field annotated or meta annotated by the given annotation.
-     *
-     * @param annotationClass the requested annotation
-     * @return the specification
-     */
-    public static Specification<Class<?>> fieldDeepAnnotatedWith(final Class<? extends Annotation> annotationClass) {
-
-        return new AbstractSpecification<Class<?>>() {
-
-            @Override
-            public boolean isSatisfiedBy(Class<?> candidate) {
-                try {
-                    if (candidate != null) {
-                        do {
-                            for (Field field : candidate.getDeclaredFields()) {
-                                if (field.isAnnotationPresent(annotationClass)) {
-                                    return true;
-                                }
-                            }
-                            candidate = candidate.getSuperclass();
-                        } while (candidate != null && candidate != Object.class);
-                    }
-                } catch (Throwable error) {  // NOSONAR
-                    logger.trace(String.format("Warning in Specification fieldAnnotatedWith. Candidate: %s, annotation: %s", candidate.getSimpleName(), annotationClass.getSimpleName()), error);
-                }
-
-                return false;
-            }
-        };
-    }
-
-    /**
-     * Checks if the candidate inherits from the given class.
-     * @param klass the requested class
-     * @return the specification
-     */
-    public static Specification<Class<?>> classInherits(final Class<?> klass) {
-        return new AbstractSpecification<Class<?>>() {
-            @Override
-            public boolean isSatisfiedBy(Class<?> candidate) {
-                return candidate != null && klass.isAssignableFrom(candidate);
-            }
-        };
-    }
-
-    /**
-     * Checks if the candidate or an ancestor is annotated or meta annotated by the given annotation.
-     *
-     * @param anoKlass the requested annotation
-     * @return the specification
-     */
-    public static Specification<Class<?>> ancestorMetaAnnotatedWith(final Class<? extends Annotation> anoKlass) {
-        return new AbstractSpecification<Class<?>>() {
-            @Override
-            public boolean isSatisfiedBy(Class<?> candidate) {
-
-                if (candidate == null) {
-                    return false;
-                }
-
-                boolean result = false;
-
-                Class<?>[] allInterfacesAndClasses = getAllInterfacesAndClasses(candidate);
-
-                for (Class<?> clazz : allInterfacesAndClasses) {
-                    boolean satisfiedBy = classMetaAnnotatedWith(anoKlass).isSatisfiedBy(clazz);
-                    if (satisfiedBy) {
-                        result = true;
-                        break;
-                    }
-                }
-
-                return result;
-            }
-        };
-    }
-
-    /**
-     * Checks if the candidate is annotated or meta annotated by the given annotation.
-     *
-     * @param klass the requested annotation
-     * @return the specification
-     */
-    public static Specification<Class<?>> classMetaAnnotatedWith(final Class<? extends Annotation> klass) {
-        return new AbstractSpecification<Class<?>>() {
-            @Override
-            public boolean isSatisfiedBy(Class<?> candidate) {
-                return candidate != null && hasAnnotationDeep(candidate, klass);
-            }
-        };
-
-    }
-
-    /**
-     * Checks if the candidate has at least one setter.
-     * @return the specification
-     */
-    public static Specification<Class<?>> classHasSetters() {
-        return new AbstractSpecification<Class<?>>() {
-            @Override
-            public boolean isSatisfiedBy(Class<?> candidate) {
-                return candidate != null &&
-                        FieldUtils.collectFields(
-                                candidate, candidate,
-                                EnumSet.of(Visibility.PUBLIC, Visibility.PROTECTED, Visibility.PRIVATE, Visibility.DEFAULT),
-                                EnumSet.of(BeanRestriction.YES_SETTER)).get(candidate)
-                                .isEmpty();
-            }
-        };
-    }
-
-    /**
-     * Checks if the candidate has only setters with the visibility package.
-     * @return the specification
-     */
-    public static Specification<Class<?>> classHasOnlyPackageViewSetters() {
-        return new AbstractSpecification<Class<?>>() {
-            @Override
-            public boolean isSatisfiedBy(Class<?> candidate) {
-                return candidate != null &&
-                        FieldUtils.collectFields(
-                                candidate, candidate,
-                                EnumSet.of(Visibility.DEFAULT),
-                                EnumSet.of(BeanRestriction.YES_SETTER)).get(candidate)
-                                .isEmpty() &&
-                        classHasSetters().isSatisfiedBy(candidate);
-            }
-        };
-    }
-
-
-    /**
-     * Checks if the given class is annotated or meta annotated with the given annotation.
-     * @param aClass the class to check
-     * @param annotationClass the requested annotation
-     * @return true if the class if annotated or meta annotated, false otherwise
-     */
-    public static boolean hasAnnotationDeep(Class<?> aClass, Class<? extends Annotation> annotationClass) {
-        if (aClass.equals(annotationClass)) {
-            return true;
-        }
-
-        for (Annotation anno : aClass.getAnnotations()) {
-            Class<? extends Annotation> annoClass = anno.annotationType();
-            if (!annoClass.getPackage().getName().startsWith("java.lang")
-                    && hasAnnotationDeep(annoClass, annotationClass)) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-
-    /**
-     * Checks if the candidate is an interface.
-     * @return the specification
-     */
-    public static Specification<Class<?>> classIsInterface() {
-        return new AbstractSpecification<Class<?>>() {
-            @Override
-            public boolean isSatisfiedBy(Class<?> candidate) {
-
-                return candidate != null && candidate.isInterface();
-            }
-        };
-    }
-
-    /**
-     * Checks if the candidate equals to the given class.
-     * @param notCandidate the class to check
-     * @return the specification
-     */
-    public static Specification<Class<?>> classIsNot(final Class<?> notCandidate) {
-        return new AbstractSpecification<Class<?>>() {
-            @Override
-            public boolean isSatisfiedBy(Class<?> candidate) {
-
-                return candidate != null && !candidate.equals(notCandidate);
-            }
-        };
-    }
-
-    /**
-     * Checks if the candidate has interface.
-     * @return the specification
-     */
-    public static Specification<Class<?>> classHasSuperInterfaces() {
-        return new AbstractSpecification<Class<?>>() {
-            @Override
-            public boolean isSatisfiedBy(Class<?> candidate) {
-                Class<?>[] interfaces = {};
-                if (candidate != null) {
-                    interfaces = candidate.getInterfaces();
-                }
-                return candidate != null && interfaces != null && interfaces.length > 0;
-            }
-        };
-    }
-
-    /**
-     * Checks if the class is an annotation
-     * @return the specification
-     */
-    public static Specification<Class<?>> classIsAnnotation() {
-        return new AbstractSpecification<Class<?>>() {
-            @Override
-            public boolean isSatisfiedBy(Class<?> candidate) {
-
-                return candidate != null && candidate.isAnnotation();
-            }
-        };
-    }
-
-    /**
-     * Checks if the class is abstract.
-     * @return the specification
-     */
-    public static Specification<Class<?>> classIsAbstract() {
-        return new AbstractSpecification<Class<?>>() {
-            @Override
-            public boolean isSatisfiedBy(Class<?> candidate) {
-
-                return candidate != null && Modifier.isAbstract(candidate.getModifiers());
-            }
-        };
-    }
-
-    /**
-     * Checks if at least one method of the class is annotated with the annotation class.
-     * @param annotationClass the requested annotation
-     * @return the specification
-     */
-    public static Specification<Class<?>> methodAnnotatedWith(final Class<? extends Annotation> annotationClass) {
-        return new ClassMethodsAnnotatedWith(annotationClass);
-    }
-
-    static Class<?>[] getAllInterfacesAndClasses(Class<?> clazz) {
-        return getAllInterfacesAndClasses(new Class[]{clazz});
-    }
-
-    /**
-     * This method walks up the inheritance hierarchy to make sure we get every class/interface/superclass/interface's superclass that could
-     * possibly contain the declaration of the annotated method we're looking for.
-     *
-     * @param classes array of class
-     * @return array of class
-     */
-    @SuppressWarnings("unchecked")
-    static Class<?>[] getAllInterfacesAndClasses(Class<?>[] classes) {
-        if (0 == classes.length) {
-            return classes;
-        } else {
-            List<Class<?>> extendedClasses = new ArrayList<Class<?>>();
-            // all interfaces hierarchy
-            for (Class<?> clazz : classes) {
-                if (clazz != null) {
-                    Class<?>[] interfaces = clazz.getInterfaces();
-                    if (interfaces != null) {
-                        extendedClasses
-                                .addAll(Arrays
-                                        .asList(interfaces));
-                    }
-                    Class<?> superclass = clazz.getSuperclass();
-                    if (superclass != null && superclass != Object.class) {
-                        extendedClasses
-                                .addAll(Arrays
-                                        .asList(superclass));
-                    }
-                }
-            }
-
-            // Class::getInterfaces() gets only interfaces/classes
-            // implemented/extended directly by a given class.
-            // We need to walk the whole way up the tree.
-            return (Class[]) ArrayUtils.addAll(classes,
-                    getAllInterfacesAndClasses(extendedClasses
-                            .toArray(new Class[extendedClasses.size()])));
-        }
-    }
-
-    /**
-     * Logical OR between the specifications.
-     * @param participants array of specification
-     * @return the specification
-     */
-    public static Specification<Class<?>> or(Specification<Class<?>>... participants) {
-        return new OrSpecification<Class<?>>(participants);
-    }
-
-    /**
-     * Logical AND between the specifications.
-     * @param participants array of specification
-     * @return the specification
-     */
-    public static Specification<Class<?>> and(Specification<Class<?>>... participants) {
-        return new AndSpecification<Class<?>>(participants);
-    }
-
-    /**
-     * The negation of the given specification
-     * @param participant the specification
-     * @return the specification
-     */
-    public static Specification<Class<?>> not(Specification<Class<?>> participant) {
-        return new NotSpecification<Class<?>>(participant);
-    }
+    public static final Specification<Class<?>> identityHandlerSpecification = and(
+                not(classIsInterface()),
+                not(classIsAbstract()),
+                descendantOf(IdentityHandler.class));
 
 }

--- a/specs/src/main/java/org/seedstack/business/assertions/BusinessReflectionAsserts.java
+++ b/specs/src/main/java/org/seedstack/business/assertions/BusinessReflectionAsserts.java
@@ -10,6 +10,9 @@
 package org.seedstack.business.assertions;
 
 
+import com.google.gag.annotation.remark.WTF;
+import org.apache.commons.collections.iterators.ArrayIterator;
+import org.kametic.specifications.Specification;
 import org.seedstack.business.api.application.annotations.ApplicationService;
 import org.seedstack.business.api.domain.GenericFactory;
 import org.seedstack.business.api.domain.GenericRepository;
@@ -20,16 +23,12 @@ import org.seedstack.business.api.domain.annotations.DomainService;
 import org.seedstack.business.api.domain.base.BaseAggregateRoot;
 import org.seedstack.business.api.domain.base.BaseEntity;
 import org.seedstack.business.api.domain.base.BaseValueObject;
-import org.seedstack.business.api.domain.meta.specifications.DomainSpecifications;
-import org.seedstack.business.assertions.BusinessAssertionsErrorCodes;
-import org.apache.commons.collections.iterators.ArrayIterator;
-import org.kametic.specifications.Specification;
 import org.seedstack.seed.core.api.SeedException;
 
 import java.lang.reflect.Modifier;
 import java.util.Iterator;
 
-
+import static org.seedstack.business.api.domain.meta.specifications.BaseClassSpecifications.*;
 /**
  * This class gives helper methods for asserting on business classes.
  * 
@@ -56,7 +55,7 @@ public final class BusinessReflectionAsserts {
 
         // we check that the constructors are not public
         $(
-                actual, DomainSpecifications.not(DomainSpecifications.classConstructorIsPublic()),
+                actual, not(classConstructorIsPublic()),
                 BusinessAssertionsErrorCodes.CLASS_CONSTRUCTORS_MUST_NOT_BE_PUBLIC,
                 CONSTRUCTOR_NAME, actual.getSimpleName(),
                 CONSTRUCTOR_CLASS_NAME, actual.getSimpleName()
@@ -64,20 +63,20 @@ public final class BusinessReflectionAsserts {
 
         // we check the class is not abstract
         $(
-                actual, DomainSpecifications.not(DomainSpecifications.classModifierIs(Modifier.ABSTRACT)),
+                actual, not(classModifierIs(Modifier.ABSTRACT)),
                 BusinessAssertionsErrorCodes.CLASS_MUST_NOT_BE_ABSTRACT, CLASS_NAME, actual.getName()
         );
 
         // we check for the annotation
         $(
-                actual, DomainSpecifications.classInherits(BaseAggregateRoot.class),
+                actual, classInherits(BaseAggregateRoot.class),
                 BusinessAssertionsErrorCodes.CLASS_MUST_EXTENDS, CLASS_NAME, actual.getName(), PARENT_CLASS_NAME, BaseAggregateRoot.class.getName(),
                 MORE, "Or one of of its children classes."
         );
 
         // we check for the annotation
         $(
-                actual, DomainSpecifications.ancestorMetaAnnotatedWith(DomainAggregateRoot.class),
+                actual, ancestorMetaAnnotatedWith(DomainAggregateRoot.class),
                 BusinessAssertionsErrorCodes.CLASS_OR_PARENT_MUST_BE_ANNOTATED_WITH
         );
 
@@ -93,26 +92,26 @@ public final class BusinessReflectionAsserts {
 		
 		// we check that the constructors are not public
         $(
-            actual , DomainSpecifications.not(DomainSpecifications.classConstructorIsPublic()) ,
+            actual , not(classConstructorIsPublic()) ,
             BusinessAssertionsErrorCodes.CLASS_CONSTRUCTORS_MUST_NOT_BE_PUBLIC ,
                 CONSTRUCTOR_CLASS_NAME, actual.getSimpleName()
 		);
 		
 		// we check the class is not abstract
         $(
-            actual, DomainSpecifications.not(DomainSpecifications.classModifierIs(Modifier.ABSTRACT)) ,
+            actual, not(classModifierIs(Modifier.ABSTRACT)) ,
             BusinessAssertionsErrorCodes.CLASS_MUST_NOT_BE_ABSTRACT  , CLASS_NAME, actual.getName() );
 		
 		// we check for the annotation
         $(
-            actual , DomainSpecifications.classInherits(BaseValueObject.class) ,
+            actual , classInherits(BaseValueObject.class) ,
             BusinessAssertionsErrorCodes.CLASS_MUST_EXTENDS , CLASS_NAME, actual.getName() , PARENT_CLASS_NAME, BaseValueObject.class.getName(),
                 MORE, "Or one of of its children classes."
 		);
 		
 		// we check value object
         $(
-            actual , DomainSpecifications.classHasOnlyPackageViewSetters()  ,
+            actual , classHasOnlyPackageViewSetters()  ,
             BusinessAssertionsErrorCodes.CLASS_MUST_HAVE_ONLY_PACKAGED_VIEW_SETTERS , CLASS_NAME, actual.getName()
         );
 	}
@@ -125,7 +124,7 @@ public final class BusinessReflectionAsserts {
 	public static void assertEntityClassIsValid(Class<?> actual) {
 		// we check that the constructors are not public
         $(
-          actual , DomainSpecifications.not(DomainSpecifications.classConstructorIsPublic()) ,
+          actual , not(classConstructorIsPublic()) ,
           BusinessAssertionsErrorCodes.CLASS_CONSTRUCTORS_MUST_NOT_BE_PUBLIC,
                 CONSTRUCTOR_NAME, actual.getSimpleName(),
                 CONSTRUCTOR_CLASS_NAME, actual.getSimpleName()
@@ -133,21 +132,21 @@ public final class BusinessReflectionAsserts {
 
         // we check the class is not abstract
         $(
-            actual, DomainSpecifications.not(DomainSpecifications.classModifierIs(Modifier.ABSTRACT)) ,
+            actual, not(classModifierIs(Modifier.ABSTRACT)) ,
             BusinessAssertionsErrorCodes.CLASS_MUST_NOT_BE_ABSTRACT  , CLASS_NAME, actual.getName()
         );
 
 
         // we check for the annotation
         $(
-            actual , DomainSpecifications.classInherits(BaseEntity.class) ,
+            actual , classInherits(BaseEntity.class) ,
             BusinessAssertionsErrorCodes.CLASS_MUST_EXTENDS , CLASS_NAME, actual.getName() , PARENT_CLASS_NAME, BaseEntity.class.getName() ,
                 MORE, "Or one of of its children classes."
         );
 
         // we check for the annotation
         $(
-            actual , DomainSpecifications.ancestorMetaAnnotatedWith(DomainEntity.class) ,
+            actual , ancestorMetaAnnotatedWith(DomainEntity.class) ,
             BusinessAssertionsErrorCodes.CLASS_OR_PARENT_MUST_BE_ANNOTATED_WITH,
                 CLASS_NAME, actual.getName() ,
                 ANNOTATION_NAME, DomainEntity.class.getName()
@@ -163,13 +162,13 @@ public final class BusinessReflectionAsserts {
 		
 		// we check the class is not abstract
         $(
-            actual, DomainSpecifications.classIsInterface() ,
+            actual, classIsInterface() ,
             BusinessAssertionsErrorCodes.CLASS_MUST_BE_INTERFACE  , CLASS_NAME, actual.getName()
 		);
 		
 		// we check for the annotation
         $(
-            actual , DomainSpecifications.classInherits(GenericRepository.class) ,
+            actual , classInherits(GenericRepository.class) ,
             BusinessAssertionsErrorCodes.CLASS_MUST_EXTENDS ,
                 CLASS_NAME, actual.getName() , PARENT_CLASS_NAME, GenericRepository.class.getName(),
                 MORE, ""
@@ -184,13 +183,13 @@ public final class BusinessReflectionAsserts {
 	public static void assertFactoryInterfaceClassIsValid(Class<?> actual) {
 		// we check the class is not abstract
         $(
-            actual, DomainSpecifications.classIsInterface(),
+            actual, classIsInterface(),
             BusinessAssertionsErrorCodes.CLASS_MUST_BE_INTERFACE, CLASS_NAME, actual.getName()
         );
 		
 		// we check for the annotation
         $(
-            actual , DomainSpecifications.classInherits(GenericFactory.class) ,
+            actual , classInherits(GenericFactory.class) ,
             BusinessAssertionsErrorCodes.CLASS_MUST_EXTENDS ,
                 CLASS_NAME, actual.getName() , PARENT_CLASS_NAME, GenericFactory.class.getName(),
                 MORE, ""
@@ -205,13 +204,13 @@ public final class BusinessReflectionAsserts {
 	public static void assertDomainServiceInterfaceClassIsValid(Class<?> actual) {
 		// we check the class is not abstract
         $(
-            actual, DomainSpecifications.classIsInterface() ,
+            actual, classIsInterface() ,
             BusinessAssertionsErrorCodes.CLASS_MUST_BE_INTERFACE  , CLASS_NAME, actual.getName()
         );
 		
 		// we check for the annotation
         $(
-            actual , DomainSpecifications.classMetaAnnotatedWith(DomainService.class),
+            actual , classMetaAnnotatedWith(DomainService.class),
             BusinessAssertionsErrorCodes.CLASS_OR_PARENT_MUST_BE_ANNOTATED_WITH,
                 CLASS_NAME, actual.getName() ,
                 ANNOTATION_NAME, DomainService.class.getName()
@@ -227,13 +226,13 @@ public final class BusinessReflectionAsserts {
 	public static void assertApplicationServiceInterfaceClassIsValid(Class<?> actual) {
 		// we check the class is not abstract
         $(
-            actual, DomainSpecifications.classIsInterface() ,
+            actual, classIsInterface() ,
             BusinessAssertionsErrorCodes.CLASS_MUST_BE_INTERFACE  , CLASS_NAME, actual.getName()
         );
 		
 		// we check for the annotation
         $(
-            actual , DomainSpecifications.classMetaAnnotatedWith(ApplicationService.class),
+            actual , classMetaAnnotatedWith(ApplicationService.class),
             BusinessAssertionsErrorCodes.CLASS_OR_PARENT_MUST_BE_ANNOTATED_WITH,
                 CLASS_NAME, actual.getName() ,
                 ANNOTATION_NAME, ApplicationService.class.getName()
@@ -248,19 +247,20 @@ public final class BusinessReflectionAsserts {
 	public static void assertDomainPolicyInterfaceClassIsValid(Class<?> actual) {
 		// we check the class is not abstract
         $(
-            actual, DomainSpecifications.classIsInterface() ,
+            actual, classIsInterface() ,
             BusinessAssertionsErrorCodes.CLASS_MUST_BE_INTERFACE  , CLASS_NAME, actual.getName()
         );
 		
 		// we check for the annotation
         $(
-            actual , DomainSpecifications.classMetaAnnotatedWith(DomainPolicy.class),
+            actual , classMetaAnnotatedWith(DomainPolicy.class),
             BusinessAssertionsErrorCodes.CLASS_OR_PARENT_MUST_BE_ANNOTATED_WITH,
                 CLASS_NAME, actual.getName() ,
                 ANNOTATION_NAME, DomainPolicy.class.getName()
         );
 	}
 
+    @WTF
     @SuppressWarnings("unchecked")
 	private static <T> void $(T actual, Specification<T> specification, BusinessAssertionsErrorCodes errorCode, String... messages) { //NOSONAR
         if (!specification.isSatisfiedBy(actual)) {

--- a/specs/src/test/java/org/seedstack/business/api/domain/DomainSpecificationsTest.java
+++ b/specs/src/test/java/org/seedstack/business/api/domain/DomainSpecificationsTest.java
@@ -1,0 +1,263 @@
+/**
+ * Copyright (c) 2013-2015 by The SeedStack authors. All rights reserved.
+ *
+ * This file is part of SeedStack, An enterprise-oriented full development stack.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.seedstack.business.api.domain;
+
+import org.junit.Test;
+import org.seedstack.business.api.application.GenericApplicationService;
+import org.seedstack.business.api.application.annotations.ApplicationService;
+import org.seedstack.business.api.domain.annotations.*;
+import org.seedstack.business.api.domain.base.BaseAggregateRoot;
+import org.seedstack.business.api.domain.base.BaseEntity;
+import org.seedstack.business.api.domain.base.BaseValueObject;
+import org.seedstack.business.api.domain.meta.specifications.DomainSpecifications;
+import org.seedstack.business.api.interfaces.GenericInterfacesService;
+import org.seedstack.business.api.interfaces.annotations.InterfacesService;
+import org.seedstack.business.api.interfaces.assembler.Assembler;
+import org.seedstack.business.api.interfaces.assembler.DtoOf;
+import org.seedstack.business.api.interfaces.assembler.TupleType;
+import org.seedstack.business.api.interfaces.query.finder.Finder;
+import org.seedstack.business.api.interfaces.query.finder.GenericFinder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Validates all the domain specifications.
+ *
+ * @author Pierre Thirouin <pierre.thirouin@ext.mpsa.com>
+ */
+public class DomainSpecificationsTest {
+
+    static class MyAggregateRoot1 extends BaseAggregateRoot<String> {
+
+        @Override
+        public String getEntityId() {
+            return "id";
+        }
+    }
+
+    @DomainAggregateRoot
+    static class MyAggregateRoot2 { }
+
+    static class MySimplePojo { }
+
+    @Test
+    public void testAggregateRootSpecification() {
+        assertThat(DomainSpecifications.aggregateRootSpecification.isSatisfiedBy(MyAggregateRoot1.class)).isTrue();
+        assertThat(DomainSpecifications.aggregateRootSpecification.isSatisfiedBy(MyAggregateRoot2.class)).isTrue();
+
+        assertThat(DomainSpecifications.aggregateRootSpecification.isSatisfiedBy(MySimplePojo.class)).isFalse();
+
+        assertThat(DomainSpecifications.aggregateRootSpecification).describedAs("specification should be comparable")
+                .isEqualTo(DomainSpecifications.aggregateRootSpecification);
+    }
+
+    static class MyEntity1 extends BaseEntity<String> {
+
+        @Override
+        public String getEntityId() {
+            return "id";
+        }
+    }
+
+    @DomainEntity
+    static class MyEntity2 { }
+
+    @Test
+    public void testEntitySpecification() {
+        assertThat(DomainSpecifications.entitySpecification.isSatisfiedBy(MyEntity1.class)).isTrue();
+        assertThat(DomainSpecifications.entitySpecification.isSatisfiedBy(MyEntity2.class)).isTrue();
+
+        assertThat(DomainSpecifications.entitySpecification.isSatisfiedBy(MySimplePojo.class)).isFalse();
+
+        assertThat(DomainSpecifications.entitySpecification).describedAs("specification should be comparable")
+                .isEqualTo(DomainSpecifications.entitySpecification);
+    }
+
+    static interface MyApplicationService1 extends GenericApplicationService { }
+
+    @ApplicationService
+    static interface MyApplicationService2 { }
+
+    @ApplicationService
+    static class MyApplicationService3 { }
+
+    @Test
+    public void testApplicationServiceSpecification() {
+        assertThat(DomainSpecifications.applicationServiceSpecification.isSatisfiedBy(MyApplicationService1.class)).isTrue();
+        assertThat(DomainSpecifications.applicationServiceSpecification.isSatisfiedBy(MyApplicationService2.class)).isTrue();
+
+        assertThat(DomainSpecifications.applicationServiceSpecification.isSatisfiedBy(MyApplicationService3.class)).isFalse();
+
+        assertThat(DomainSpecifications.applicationServiceSpecification).describedAs("specification should be comparable")
+                .isEqualTo(DomainSpecifications.applicationServiceSpecification);
+    }
+
+    static class MyAssembler1 implements Assembler<MyAggregateRoot1, MySimplePojo, TupleType> {
+        @Override
+        public MySimplePojo assembleDtoFromAggregate(MyAggregateRoot1 sourceAggregate) { return null; }
+
+        @Override
+        public void updateDtoFromAggregate(MySimplePojo sourceDto, MyAggregateRoot1 sourceAggregate) { }
+
+        @Override
+        public void mergeAggregateWithDto(MyAggregateRoot1 targetAggregate, MySimplePojo sourceDto) { }
+
+        @Override
+        public TupleType getAggregateClass() { return null; }
+
+        @Override
+        public Class<MySimplePojo> getDtoClass() { return null; }
+    }
+
+    @Test
+    public void testAssemblerSpecification() {
+        assertThat(DomainSpecifications.assemblerSpecification.isSatisfiedBy(MyAssembler1.class)).isTrue();
+
+        assertThat(DomainSpecifications.assemblerSpecification.isSatisfiedBy(MySimplePojo.class)).isFalse();
+
+        assertThat(DomainSpecifications.assemblerSpecification).describedAs("specification should be comparable")
+                .isEqualTo(DomainSpecifications.assemblerSpecification);
+    }
+
+    @DomainFactory
+    static interface MyFactory1 {}
+
+    static interface MyFactory2 extends GenericFactory<MyAggregateRoot1> {}
+
+    @DomainFactory
+    static class MyFactory3 {}
+
+    @Test
+    public void testDomainFactorySpecification() {
+        assertThat(DomainSpecifications.domainFactorySpecification.isSatisfiedBy(MyFactory1.class)).isTrue();
+        assertThat(DomainSpecifications.domainFactorySpecification.isSatisfiedBy(MyFactory2.class)).isTrue();
+
+        assertThat(DomainSpecifications.domainFactorySpecification.isSatisfiedBy(MyFactory3.class)).isFalse();
+
+        assertThat(DomainSpecifications.domainFactorySpecification).describedAs("specification should be comparable")
+                .isEqualTo(DomainSpecifications.domainFactorySpecification);
+    }
+
+    @DomainRepository
+    static interface MyRepository1 {}
+
+    static interface MyRepository2 extends GenericRepository<MyAggregateRoot1, String> {}
+
+    @DomainRepository
+    static class MyRepository3 {}
+
+    @Test
+    public void testDomainRepoSpecification() {
+        assertThat(DomainSpecifications.domainRepoSpecification.isSatisfiedBy(MyRepository1.class)).isTrue();
+        assertThat(DomainSpecifications.domainRepoSpecification.isSatisfiedBy(MyRepository2.class)).isTrue();
+
+        assertThat(DomainSpecifications.domainRepoSpecification.isSatisfiedBy(MyRepository3.class)).isFalse();
+    }
+
+    @DomainRepositoryImpl
+    static class MyRepositoryImpl1 {}
+
+    @Test
+    public void testDomainRepoImplSpecification() {
+        assertThat(DomainSpecifications.domainRepoImplSpecification.isSatisfiedBy(MyRepositoryImpl1.class)).isTrue();
+
+        assertThat(DomainSpecifications.domainRepoImplSpecification.isSatisfiedBy(MyRepository1.class)).isFalse();
+    }
+
+    @DomainService
+    static interface MyDomainServiceSpecification1 {}
+
+    static interface MyDomainServiceSpecification2 extends GenericDomainService {}
+
+    static class MyDomainServiceSpecification3 implements GenericDomainService {}
+
+    @Test
+    public void testDomainServiceSpecification() {
+        assertThat(DomainSpecifications.domainServiceSpecification.isSatisfiedBy(MyDomainServiceSpecification1.class)).isTrue();
+        assertThat(DomainSpecifications.domainServiceSpecification.isSatisfiedBy(MyDomainServiceSpecification2.class)).isTrue();
+
+        assertThat(DomainSpecifications.domainServiceSpecification.isSatisfiedBy(MyDomainServiceSpecification3.class)).isFalse();
+    }
+
+    @InterfacesService
+    static interface MyInterfacesServiceSpecification1 {}
+
+    static interface MyInterfacesServiceSpecification2 extends GenericInterfacesService {}
+
+    static class MyInterfacesServiceSpecification3 implements GenericInterfacesService {}
+
+    @Test
+    public void testInterfacesServiceSpecification() {
+        assertThat(DomainSpecifications.interfacesServiceSpecification.isSatisfiedBy(MyInterfacesServiceSpecification1.class)).isTrue();
+        assertThat(DomainSpecifications.interfacesServiceSpecification.isSatisfiedBy(MyInterfacesServiceSpecification2.class)).isTrue();
+
+        assertThat(DomainSpecifications.interfacesServiceSpecification.isSatisfiedBy(MyInterfacesServiceSpecification3.class)).isFalse();
+    }
+
+    @DtoOf(MyAggregateRoot1.class)
+    static class MyPojo1 {}
+
+    @DtoOf({MyAggregateRoot1.class, MyAggregateRoot1.class})
+    static class MyPojo2 {}
+
+    @Test
+    public void testDtoWithDefaultAssemblerSpecification() {
+        assertThat(DomainSpecifications.dtoWithDefaultAssemblerSpecification.isSatisfiedBy(MyPojo1.class)).isTrue();
+        assertThat(DomainSpecifications.dtoWithDefaultAssemblerSpecification.isSatisfiedBy(MyPojo2.class)).isTrue();
+
+        assertThat(DomainSpecifications.dtoWithDefaultAssemblerSpecification.isSatisfiedBy(MySimplePojo.class)).isFalse();
+    }
+
+    @Finder
+    static interface MyFinder1 {}
+
+    static interface MyFinder2 extends GenericFinder {}
+
+    @Finder
+    static class MyFinder3 {}
+
+    @Test
+    public void testFinderServiceSpecification() {
+        assertThat(DomainSpecifications.finderServiceSpecification.isSatisfiedBy(MyFinder1.class)).isTrue();
+        assertThat(DomainSpecifications.finderServiceSpecification.isSatisfiedBy(MyFinder2.class)).isTrue();
+
+        assertThat(DomainSpecifications.finderServiceSpecification.isSatisfiedBy(MyFinder3.class)).isFalse();
+    }
+
+    @DomainPolicy
+    static interface MyPolicy1 {}
+
+    static interface MyPolicy2 extends GenericDomainPolicy {}
+
+    @DomainPolicy
+    static class MyPolicy3 {}
+
+    @Test
+    public void testPolicyServiceSpecification() {
+        assertThat(DomainSpecifications.policySpecification.isSatisfiedBy(MyPolicy1.class)).isTrue();
+        assertThat(DomainSpecifications.policySpecification.isSatisfiedBy(MyPolicy2.class)).isTrue();
+
+        assertThat(DomainSpecifications.policySpecification.isSatisfiedBy(MyPolicy3.class)).isFalse();
+    }
+
+    @DomainValueObject
+    static class MyValueObject1 {}
+
+    static class MyValueObject2 extends BaseValueObject {}
+
+
+    @Test
+    public void testValueObjectServiceSpecification() {
+        assertThat(DomainSpecifications.valueObjectSpecification.isSatisfiedBy(MyValueObject1.class)).isTrue();
+        assertThat(DomainSpecifications.valueObjectSpecification.isSatisfiedBy(MyValueObject2.class)).isTrue();
+
+        assertThat(DomainSpecifications.valueObjectSpecification.isSatisfiedBy(MySimplePojo.class)).isFalse();
+    }
+}

--- a/specs/src/test/resources/logback-test.xml
+++ b/specs/src/test/resources/logback-test.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<!--
+
+    Copyright (c) 2013-2015 by The SeedStack authors. All rights reserved.
+
+    This file is part of SeedStack, An enterprise-oriented full development stack.
+
+    This Source Code Form is subject to the terms of the Mozilla Public
+    License, v. 2.0. If a copy of the MPL was not distributed with this
+    file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+-->
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+    <root level="INFO">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>


### PR DESCRIPTION
- Extracted all the specifications from the `BusinessPlugin` (and the `IdentityHandlerPlugin`) and add them in the `DomainSpecification` class.

> These specifications are static final fields not methods as they should be comparable and not instantiated each time.
- I also removed generic specification like `and()`, `or()`, etc. from plugin and `DomainSpecification`. I placed them in `BaseClassSpecification` for now but it should be pushed up to kametic/specifications.

This PR will improve the testability of the plugins and will also allow to reuse domain specifications.

It could be done in the same time as this issue: nuun-io/kernel#32
