### PR TITLE
Added support for tuple in the assembler DSL

### DIFF
--- a/core/src/it/resources/logback-test.xml
+++ b/core/src/it/resources/logback-test.xml
@@ -16,6 +16,10 @@
             <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
         </encoder>
     </appender>
+
+    <logger name="org.reflections" level="OFF"/>
+    <logger name="io.nuun" level="WARN"/>
+
     <root level="INFO">
         <appender-ref ref="STDOUT" />
     </root>

--- a/core/src/main/java/org/seedstack/business/core/domain/FactoryInternal.java
+++ b/core/src/main/java/org/seedstack/business/core/domain/FactoryInternal.java
@@ -23,6 +23,7 @@ import org.seedstack.seed.core.utils.SeedCheckUtils;
 
 import javax.inject.Inject;
 import java.lang.reflect.Constructor;
+import java.util.Arrays;
 
 /**
  * FactoryInternal allows the creations of {@link org.seedstack.business.api.domain.DomainObject} objects using their constructors.
@@ -79,17 +80,17 @@ public class FactoryInternal<DO extends DomainObject & Producible> implements Fa
 		Constructor<?> constructor = MethodMatcher.findMatchingConstructor(getProducedClass(), args);
 		DO domainObject;
 		if (constructor == null) {
-			throw SeedException.createNew(DomainErrorCodes.DOMAIN_OBJECT_CONSTRUCTOR_NOT_FOUND)
-					.put("domainObject", getProducedClass().getSimpleName()).put("parameters", args);
-		}
-		try {
+            throw SeedException.createNew(DomainErrorCodes.DOMAIN_OBJECT_CONSTRUCTOR_NOT_FOUND)
+                    .put("domainObject", getProducedClass()).put("parameters", Arrays.toString(args));
+        }
+        try {
 			constructor.setAccessible(true);
             //noinspection unchecked
             domainObject = (DO) constructor.newInstance(args);
 
 		} catch (Exception e) {
 			throw SeedException.wrap(e, DomainErrorCodes.UNABLE_TO_INVOKE_CONSTRUCTOR).put("constructor", constructor)
-					.put("domainObject", getProducedClass().getSimpleName()).put("parameters", args);
+					.put("domainObject", getProducedClass()).put("parameters", Arrays.toString(args));
 		}
 		return domainObject;
 	}

--- a/core/src/main/java/org/seedstack/business/core/interfaces/assembler/dsl/AggAssemblerProviderImpl.java
+++ b/core/src/main/java/org/seedstack/business/core/interfaces/assembler/dsl/AggAssemblerProviderImpl.java
@@ -10,10 +10,13 @@
 package org.seedstack.business.core.interfaces.assembler.dsl;
 
 import org.javatuples.Tuple;
+import org.seedstack.business.api.Tuples;
 import org.seedstack.business.api.domain.AggregateRoot;
 import org.seedstack.business.api.interfaces.assembler.Assembler;
 import org.seedstack.business.api.interfaces.assembler.dsl.*;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -36,8 +39,12 @@ public class AggAssemblerProviderImpl implements BaseAggAssemblerProvider, AggAs
     }
 
     @Override
-    public <T extends Tuple> TupleAggAssemblerWithRepoProvider<T> to(T aggregateRootTuple) {
-        assemblerContext.setAggregateClasses(aggregateRootTuple);
+    public <T extends Tuple> TupleAggAssemblerWithRepoProvider<T> to(Class<? extends AggregateRoot<?>> firstAggregateClass, Class<? extends AggregateRoot<?>> secondAggregateClass, Class<? extends AggregateRoot<?>>... otherAggregateClasses) {
+        List<Class<?>> aggregateRootClasses = new ArrayList<Class<?>>();
+        aggregateRootClasses.add(firstAggregateClass);
+        aggregateRootClasses.add(secondAggregateClass);
+        aggregateRootClasses.addAll(Arrays.asList(otherAggregateClasses));
+        assemblerContext.setAggregateClasses(Tuples.create((List)aggregateRootClasses));
         return new TupleAggAssemblerWithRepoProviderImpl<T>(registry, assemblerContext);
     }
 

--- a/core/src/main/java/org/seedstack/business/core/interfaces/assembler/dsl/AggAssemblerWithRepoProviderImpl.java
+++ b/core/src/main/java/org/seedstack/business/core/interfaces/assembler/dsl/AggAssemblerWithRepoProviderImpl.java
@@ -11,9 +11,12 @@ package org.seedstack.business.core.interfaces.assembler.dsl;
 
 import org.seedstack.business.api.domain.AggregateRoot;
 import org.seedstack.business.api.domain.GenericFactory;
+import org.seedstack.business.api.domain.Repository;
+import org.seedstack.business.api.interfaces.assembler.Assembler;
 import org.seedstack.business.api.interfaces.assembler.dsl.AggAssemblerWithRepoAndFactProvider;
 import org.seedstack.business.api.interfaces.assembler.dsl.AggAssemblerWithRepoProvider;
 import org.seedstack.business.api.interfaces.assembler.dsl.AggregateNotFoundException;
+import org.seedstack.business.api.interfaces.assembler.resolver.ParameterHolder;
 
 /**
  * @author Pierre Thirouin <pierre.thirouin@ext.mpsa.com>
@@ -36,8 +39,22 @@ public class AggAssemblerWithRepoProviderImpl<A extends AggregateRoot<?>> extend
     @Override
     public A fromFactory() {
         GenericFactory<A> genericFactory = (GenericFactory<A>) registry.genericFactoryOf(assemblerContext.getAggregateClass());
-        A aggregateRoot = (A) getAggregateFromFactory(genericFactory, assemblerContext.getAggregateClass());
+        ParameterHolder parameterHolder = dtoInfoResolver.resolveAggregate(assemblerContext.getDto());
+        A aggregateRoot = (A) getAggregateFromFactory(genericFactory, assemblerContext.getAggregateClass(), parameterHolder.parameters());
         return assembleWithDto(aggregateRoot);
+    }
+
+    /**
+     * Loads an aggregate roots from a repository.
+     *
+     * @param key the aggregate roots identity
+     * @param <A> the aggregate root type
+     * @return the loaded aggregate root
+     */
+    protected <A> A loadFromRepo(Object key) {
+        Repository repository = assemblerContext.getRepository();
+        //noinspection unchecked
+        return (A) repository.load(key);
     }
 
     // --------------------------- AggAssemblerWithRepoAndFactProvider methods
@@ -67,6 +84,20 @@ public class AggAssemblerWithRepoProviderImpl<A extends AggregateRoot<?>> extend
             // otherwise fallback on the factory
             return fromFactory();
         }
+    }
+
+    /**
+     * Assemble one or a tuple of aggregate root from a dto.
+     *
+     * @param aggregateRoots the aggregate root(s) to assemble
+     * @param <T> type of aggregate root(s). It could be a {@code Tuple} or an {@code AggregateRoot}
+     * @return the assembled aggregate root(s)
+     */
+    protected  <T> T assembleWithDto(T aggregateRoots) {
+        Assembler assembler = registry.assemblerOf(assemblerContext.getAggregateClass(), assemblerContext.getDto().getClass());
+        //noinspection unchecked
+        assembler.mergeAggregateWithDto(aggregateRoots, assemblerContext.getDto());
+        return aggregateRoots;
     }
 
 }

--- a/core/src/main/java/org/seedstack/business/core/interfaces/assembler/dsl/BaseAggAssemblerWithRepoProviderImpl.java
+++ b/core/src/main/java/org/seedstack/business/core/interfaces/assembler/dsl/BaseAggAssemblerWithRepoProviderImpl.java
@@ -9,8 +9,9 @@
  */
 package org.seedstack.business.core.interfaces.assembler.dsl;
 
+import org.javatuples.Tuple;
+import org.seedstack.business.api.Tuples;
 import org.seedstack.business.api.domain.*;
-import org.seedstack.business.api.interfaces.assembler.Assembler;
 import org.seedstack.business.api.interfaces.assembler.resolver.DtoInfoResolver;
 import org.seedstack.business.api.interfaces.assembler.resolver.ParameterHolder;
 import org.seedstack.business.core.interfaces.assembler.resolver.AnnotationResolver;
@@ -20,7 +21,9 @@ import org.seedstack.seed.core.utils.SeedCheckUtils;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 /**
  * @author Pierre Thirouin <pierre.thirouin@ext.mpsa.com>
@@ -42,88 +45,94 @@ public class BaseAggAssemblerWithRepoProviderImpl {
         this.assemblerContext = assemblerContext;
     }
 
-    /**
-     * Assemble one or a tuple of aggregate root from a dto.
-     *
-     * @param aggregateRoots the aggregate root(s) to assemble
-     * @param <T> type of aggregate root(s). It could be a {@code Tuple} or an {@code AggregateRoot}
-     * @return the assembled aggregate root(s)
-     */
-    protected  <T> T assembleWithDto(T aggregateRoots) {
-        Assembler assembler = registry.assemblerOf(assemblerContext.getAggregateClass(), assemblerContext.getDto().getClass());
-        //noinspection unchecked
-        assembler.mergeAggregateWithDto(aggregateRoots, assemblerContext.getDto());
-        return aggregateRoots;
-    }
-
-    /**
-     * Loads an aggregate roots from a repository.
-     *
-     * @param key the aggregate roots identity
-     * @param <A> the aggregate root type
-     * @return the loaded aggregate root
-     */
-    protected <A> A loadFromRepo(Object key) {
-        Repository repository = assemblerContext.getRepository();
-        //noinspection unchecked
-        return (A) repository.load(key);
-    }
-
     protected Object resolveId(Object dto, Class<? extends AggregateRoot<?>> aggregateRootClass) {
-        Object id;
+        SeedCheckUtils.checkIfNotNull(dto);
+        SeedCheckUtils.checkIfNotNull(aggregateRootClass);
 
         ParameterHolder parameterHolder = dtoInfoResolver.resolveId(dto);
         if (parameterHolder.isEmpty()) {
             throw new IllegalArgumentException("No id found in the DTO. Please check the @MatchingEntityId annotation.");
         }
 
-        //noinspection unchecked
-        Class<? extends DomainObject> aggregateIdClass = (Class<? extends DomainObject>) BusinessUtils.getAggregateIdClass(aggregateRootClass);
-        // TODO <pith> : check the case when one of the parameters is null
-        if (parameterHolder.first() != null && aggregateIdClass.isAssignableFrom(parameterHolder.first().getClass())) {
-            // The first parameter is already the id we are looking for
-            id = parameterHolder.first();
-        } else {
-            // Get the "magic" factory for the aggregate id class
-            Factory<?> factory = registry.defaultFactoryOf(aggregateIdClass);
-            // Create the id based on the id constructor matching the given parameters
-            id = factory.create(parameterHolder.parameters());
-            // TODO <pith> : what if there is an actual factory for this value object ?
-        }
+        return paramsToIds(aggregateRootClass, parameterHolder, -1);
+    }
 
-        if (id == null) {
+    protected Tuple resolveIds(Object dto, Tuple aggregateRootClasses) {
+        SeedCheckUtils.checkIfNotNull(dto);
+        SeedCheckUtils.checkIfNotNull(aggregateRootClasses);
+
+        ParameterHolder parameterHolder = dtoInfoResolver.resolveId(dto);
+        if (parameterHolder.isEmpty()) {
             throw new IllegalArgumentException("No id found in the DTO. Please check the @MatchingEntityId annotation.");
         }
 
+        List<Object> ids = new ArrayList<Object>();
+        int aggregateIndex = 0;
+        for (Object aggregateRootClass : aggregateRootClasses) {
+            //noinspection unchecked
+            ids.add(paramsToIds((Class<? extends AggregateRoot<?>>) aggregateRootClass, parameterHolder, aggregateIndex));
+            aggregateIndex++;
+        }
+
+        return Tuples.create(ids);
+    }
+
+    private Object paramsToIds(Class<? extends AggregateRoot<?>> aggregateRootClass, ParameterHolder parameterHolder, int aggregateIndex) {
+        Object id;
+
+        //noinspection unchecked
+        Class<? extends DomainObject> aggregateIdClass = (Class<? extends DomainObject>) BusinessUtils.getAggregateIdClass(aggregateRootClass);
+
+        Object element = parameterHolder.uniqueElementForAggregateRoot(aggregateIndex);
+        if (element != null && aggregateIdClass.isAssignableFrom(element.getClass())) {
+            // The first parameter is already the id we are looking for
+            id = element;
+        } else {
+            if (!ValueObject.class.isAssignableFrom(aggregateIdClass)) {
+                throw new IllegalStateException("The " + aggregateRootClass.getCanonicalName() + "'s id is not a value object, so you don't have to specify the index in @MatchingEntityId(index = 0)");
+            }
+            // Get the "magic" factory for the aggregate id class
+            Factory<?> factory = registry.defaultFactoryOf(aggregateIdClass);
+            // Create the id based on the id constructor matching the given parameters
+            // TODO <pith> : check the case when one of the parameters is null
+            id = factory.create(parameterHolder.parametersOfAggregateRoot(aggregateIndex));
+        }
+        if (id == null) {
+            throw new IllegalArgumentException("No id found in the DTO. Please check the @MatchingEntityId annotation.");
+        }
         return id;
     }
 
-    protected Object getAggregateFromFactory(GenericFactory<?> factory, Class<? extends AggregateRoot<?>> aggregateClass) {
+    protected Object getAggregateFromFactory(GenericFactory<?> factory, Class<? extends AggregateRoot<?>> aggregateClass, Object[] parameters) {
         SeedCheckUtils.checkIfNotNull(factory);
         SeedCheckUtils.checkIfNotNull(aggregateClass);
+        SeedCheckUtils.checkIfNotNull(parameters);
 
-        // Extract the factory parameters from the DTO (using @MatchingFactoryParameter)
-        ParameterHolder parameterHolder = dtoInfoResolver.resolveAggregate(assemblerContext.getDto());
-        if (parameterHolder.isEmpty()) {
-            throw new IllegalArgumentException("No factory parameters found in the DTO. Please check the @MatchingFactoryParameter annotation.");
+        if (parameters.length == 0) {
+            throw new IllegalArgumentException(assemblerContext.getDto().getClass() + " - No factory parameters found in the DTO. Please check the @MatchingFactoryParameter annotation.");
         }
 
-        // Find the method in the factory which match the signature determined with the previously extracted parameters
-        Method factoryMethod = MethodMatcher.findMatchingMethod(factory.getClass(), aggregateClass, parameterHolder.parameters());
-        if (factoryMethod == null) {
-            throw new IllegalStateException(factory.getClass().getSimpleName() +
-                    ": Enable to find a method matching the parameter [" +
-                    Arrays.toString(parameterHolder.parameters()) + "]");
-        }
+        if (Factory.class.isAssignableFrom(factory.getClass())) {
+            Factory<?> defaultFactory = (Factory<?>) factory;
+            return defaultFactory.create(parameters);
+        } else {
+            // Find the method in the factory which match the signature determined with the previously extracted parameters
+            Method factoryMethod = MethodMatcher.findMatchingMethod(factory.getClass(), aggregateClass, parameters);
+            if (factoryMethod == null) {
+                throw new IllegalStateException(factory.getClass().getSimpleName() +
+                        " - Enable to find a method matching the parameters " +
+                        Arrays.toString(parameters));
+            }
 
-        // Invoke the factory to create the aggregate root
-        try {
-            //noinspection unchecked
-            return factoryMethod.invoke(factory, parameterHolder.parameters());
-        } catch (IllegalAccessException e) {
-            throw new IllegalStateException("Failed to call " + factoryMethod.getName(), e);
-        } catch (InvocationTargetException e) {
-            throw new IllegalStateException("Failed to call " + factoryMethod.getName(), e);
+            // Invoke the factory to create the aggregate root
+            try {
+                //noinspection unchecked
+                return factoryMethod.invoke(factory, parameters);
+            } catch (IllegalAccessException e) {
+                throw new IllegalStateException("Failed to call " + factoryMethod.getName(), e);
+            } catch (InvocationTargetException e) {
+                throw new IllegalStateException("Failed to call " + factoryMethod.getName(), e);
+            }
         }
     }
 }

--- a/core/src/main/java/org/seedstack/business/core/interfaces/assembler/dsl/InternalRegistryInternal.java
+++ b/core/src/main/java/org/seedstack/business/core/interfaces/assembler/dsl/InternalRegistryInternal.java
@@ -73,10 +73,10 @@ public class InternalRegistryInternal implements InternalRegistry {
     public Assembler<?, ?> tupleAssemblerOf(Tuple aggregateRootTuple, Class<?> dto) {
         List<Class<? extends AggregateRoot<?>>> aggregateClasses = Lists.newArrayList();
         for (Object o : aggregateRootTuple) {
-            if (!(o instanceof AggregateRoot<?>)) {
+            if (!(o instanceof Class<?>) || !AggregateRoot.class.isAssignableFrom((Class)o)) {
                 throw new IllegalArgumentException("The aggregateRootTuple parameter should only contain aggregates. But found " + o);
             }
-            aggregateClasses.add((Class<? extends AggregateRoot<?>>) o.getClass());
+            aggregateClasses.add((Class<? extends AggregateRoot<?>>) o);
         }
         return tupleAssemblerOf(aggregateClasses, dto);
     }

--- a/core/src/main/java/org/seedstack/business/internal/event/EventModule.java
+++ b/core/src/main/java/org/seedstack/business/internal/event/EventModule.java
@@ -65,7 +65,7 @@ class EventModule extends AbstractModule {
     protected void configure() {
         for (Class<? extends EventHandler> eventHandlerClass : eventHandlerClasses) {
             bind(eventHandlerClass);
-            LOGGER.info("binding {} in scope {}", eventHandlerClass, Scopes.NO_SCOPE);
+            LOGGER.debug("binding {} in scope {}", eventHandlerClass, Scopes.NO_SCOPE);
         }
         bind(EVENT_HANDLER_MAP_TYPE_LITERAL).toInstance(eventHandlersByEvent);
         bind(EventService.class).to(EventServiceInternal.class).in(Scopes.SINGLETON);

--- a/core/src/test/java/org/seedstack/business/core/interfaces/assembler/dsl/AssembleTest.java
+++ b/core/src/test/java/org/seedstack/business/core/interfaces/assembler/dsl/AssembleTest.java
@@ -49,8 +49,7 @@ public class AssembleTest {
         order = fluently.assemble().securely().dto(orderDto).to(Order.class).fromFactory();
 
         // list of dto to tuple of aggregates
-        Pair<Order, Customer> aggregateClass = Tuples.create(Order.class, Customer.class);
-        Pair<Order, Customer> orderCustomerPair = fluently.assemble().dto(orderDto).to(aggregateClass).fromFactory();
+        Pair<Order, Customer> orderCustomerPair = fluently.assemble().dto(orderDto).<Pair<Order, Customer>>to(Order.class, Customer.class).fromFactory();
 
         // list of dtos to list of aggregates
         orders = fluently.assemble().dtos(dtos).to(orders);

--- a/core/src/test/java/org/seedstack/business/core/interfaces/assembler/dsl/fixture/Customer.java
+++ b/core/src/test/java/org/seedstack/business/core/interfaces/assembler/dsl/fixture/Customer.java
@@ -20,16 +20,13 @@ public class Customer extends BaseAggregateRoot<String> {
 
     String name;
 
+    public Customer(String id) {
+        this.id = id;
+    }
+
     @Override
     public String getEntityId() {
         return id;
-    }
-
-    public Customer() {
-    }
-
-    public Customer(String name) {
-        this.name = name;
     }
 
     public String getName() {

--- a/core/src/test/java/org/seedstack/business/core/interfaces/assembler/dsl/fixture/CustomerRepository.java
+++ b/core/src/test/java/org/seedstack/business/core/interfaces/assembler/dsl/fixture/CustomerRepository.java
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) 2013-2015 by The SeedStack authors. All rights reserved.
+ *
+ * This file is part of SeedStack, An enterprise-oriented full development stack.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.seedstack.business.core.interfaces.assembler.dsl.fixture;
+
+import org.seedstack.business.api.domain.GenericRepository;
+
+/**
+ * @author Pierre Thirouin <pierre.thirouin@ext.mpsa.com>
+ */
+public interface CustomerRepository extends GenericRepository<Customer, String> {
+}

--- a/core/src/test/java/org/seedstack/business/core/interfaces/assembler/dsl/fixture/CustomerRepositoryInternal.java
+++ b/core/src/test/java/org/seedstack/business/core/interfaces/assembler/dsl/fixture/CustomerRepositoryInternal.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2013-2015 by The SeedStack authors. All rights reserved.
+ *
+ * This file is part of SeedStack, An enterprise-oriented full development stack.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.seedstack.business.core.interfaces.assembler.dsl.fixture;
+
+import org.assertj.core.util.Maps;
+import org.seedstack.business.core.domain.base.BaseRepository;
+
+import java.util.Map;
+
+/**
+ * @author Pierre Thirouin <pierre.thirouin@ext.mpsa.com>
+ */
+public class CustomerRepositoryInternal extends BaseRepository<Customer, String> implements CustomerRepository {
+
+    private static Map<String, Customer> orderMap = Maps.newConcurrentHashMap();
+
+    @Override
+    protected Customer doLoad(String id) {
+        return orderMap.get(id);
+    }
+
+    @Override
+    protected void doDelete(String id) {
+        orderMap.remove(id);
+    }
+
+    @Override
+    protected void doDelete(Customer order) {
+        for (Customer order1 : orderMap.values()) {
+            if (order1.equals(order)) {
+                orderMap.remove(order.getEntityId());
+            }
+        }
+    }
+
+    @Override
+    protected void doPersist(Customer order) {
+        orderMap.put(order.getEntityId(), order);
+    }
+
+    @Override
+    protected Customer doSave(Customer order) {
+        return orderMap.put(order.getEntityId(), order);
+    }
+
+    public void clear() {
+        orderMap.clear();
+    }
+}

--- a/core/src/test/java/org/seedstack/business/core/interfaces/assembler/dsl/fixture/Recipe.java
+++ b/core/src/test/java/org/seedstack/business/core/interfaces/assembler/dsl/fixture/Recipe.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) 2013-2015 by The SeedStack authors. All rights reserved.
+ *
+ * This file is part of SeedStack, An enterprise-oriented full development stack.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.seedstack.business.core.interfaces.assembler.dsl.fixture;
+
+import org.seedstack.business.api.interfaces.assembler.DtoOf;
+import org.seedstack.business.api.interfaces.assembler.MatchingEntityId;
+import org.seedstack.business.api.interfaces.assembler.MatchingFactoryParameter;
+
+/**
+ * The recipe assembled based on an order and the customer who passed the order.
+ *
+ * @author Pierre Thirouin <pierre.thirouin@ext.mpsa.com>
+ */
+// As no assembler implementation is provided the following annotation is required
+@DtoOf({Order.class, Customer.class})
+public class Recipe {
+
+    private String customerId;
+
+    private String customerName;
+
+    private String product;
+
+    private String orderId;
+
+    public Recipe(String customerId, String customerName, String orderId, String product) {
+        this.customerId = customerId;
+        this.customerName = customerName;
+        this.product = product;
+        this.orderId = orderId;
+    }
+
+    // The order of the typeIndex depends on the position in @DtoOf
+    @MatchingEntityId(typeIndex = 0) // Don't specify the index as it is not a value object id
+    @MatchingFactoryParameter(typeIndex = 0, index = 0)
+    public String getOrderId() {
+        return orderId;
+    }
+
+    @MatchingFactoryParameter(typeIndex = 0, index = 1)
+    public String getProduct() {
+        return product;
+    }
+
+    @MatchingEntityId(typeIndex = 1)
+    @MatchingFactoryParameter(typeIndex = 1, index = 0)
+    public String getCustomerId() {
+        return customerId;
+    }
+
+    // No annotation require here as the customer name is not part of
+    // the customer id or factory method
+    public String getCustomerName() {
+        return customerName;
+    }
+}

--- a/core/src/test/java/org/seedstack/business/core/interfaces/assembler/resolver/ParameterHolderTest.java
+++ b/core/src/test/java/org/seedstack/business/core/interfaces/assembler/resolver/ParameterHolderTest.java
@@ -1,0 +1,85 @@
+/**
+ * Copyright (c) 2013-2015 by The SeedStack authors. All rights reserved.
+ *
+ * This file is part of SeedStack, An enterprise-oriented full development stack.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.seedstack.business.core.interfaces.assembler.resolver;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+import org.seedstack.business.api.interfaces.assembler.resolver.ParameterHolder;
+
+/**
+ * Test {@link org.seedstack.business.api.interfaces.assembler.resolver.ParameterHolder} implementation.
+ *
+ * @author Pierre Thirouin <pierre.thirouin@ext.mpsa.com>
+ */
+public class ParameterHolderTest {
+
+    private static final String SOURCE = "MyDto.getSomeParam()";
+    private static final int param1 = 1;
+    private static final int param2 = 2;
+    private static final int param3 = 3;
+
+    @Test
+    public void testPutParameter() {
+        ParameterHolder parameterHolder = new ParameterHolderInternal();
+
+        parameterHolder.put(SOURCE, 1, param2);
+        parameterHolder.put(SOURCE, 0, param1);
+        parameterHolder.put(SOURCE, 2, param3);
+
+        Assertions.assertThat(parameterHolder.isEmpty()).isFalse();
+
+        Assertions.assertThat(parameterHolder.uniqueElement()).isNull();
+
+        Assertions.assertThat(parameterHolder.parameters()).isNotEmpty();
+        Assertions.assertThat(parameterHolder.parameters()).isEqualTo(new Object[]{1,2,3});
+        Assertions.assertThat(parameterHolder.parameters()).isEqualTo(parameterHolder.parametersOfAggregateRoot(-1));
+    }
+    @Test
+    public void testUniqueElement() {
+        ParameterHolder parameterHolder = new ParameterHolderInternal();
+
+        parameterHolder.put(SOURCE, -1, param1);
+
+        Assertions.assertThat(parameterHolder.uniqueElement()).isEqualTo(1);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testPutParameterFail() {
+        ParameterHolder parameterHolder = new ParameterHolderInternal();
+
+        parameterHolder.put(SOURCE, 0, param1);
+        parameterHolder.put(SOURCE, 0, param2);
+    }
+
+    @Test
+    public void testPutParameterWithMultipleAggregate() {
+        ParameterHolder parameterHolder = new ParameterHolderInternal();
+
+        parameterHolder.put(SOURCE, 0, 0, param1);
+        parameterHolder.put(SOURCE, 0, 1, param2);
+        parameterHolder.put(SOURCE, 1, 0, param3);
+
+        Assertions.assertThat(parameterHolder.isEmptyForAggregateRoot(0)).isFalse();
+        Assertions.assertThat(parameterHolder.isEmptyForAggregateRoot(1)).isFalse();
+        Assertions.assertThat(parameterHolder.isEmpty()).isFalse();
+
+        Assertions.assertThat(parameterHolder.parameters()).isEmpty();
+        Assertions.assertThat(parameterHolder.parametersOfAggregateRoot(0)).isEqualTo(new Object[]{1, 2});
+        Assertions.assertThat(parameterHolder.parametersOfAggregateRoot(1)).isEqualTo(new Object[]{3});
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testPutParameterFailWithMultipleAggregate() {
+        ParameterHolder parameterHolder = new ParameterHolderInternal();
+
+        parameterHolder.put(SOURCE, 2, 1, param1);
+        parameterHolder.put(SOURCE, 2, 1, param2);
+    }
+}

--- a/core/src/test/java/org/seedstack/business/core/interfaces/assembler/resolver/sample/Case2Dto.java
+++ b/core/src/test/java/org/seedstack/business/core/interfaces/assembler/resolver/sample/Case2Dto.java
@@ -36,4 +36,8 @@ public class Case2Dto {
     public Date getBirthDate() {
         return birthDate;
     }
+
+    public String otherDetails() {
+        return "something";
+    }
 }

--- a/core/src/test/java/org/seedstack/business/core/interfaces/assembler/resolver/sample/Case3Dto.java
+++ b/core/src/test/java/org/seedstack/business/core/interfaces/assembler/resolver/sample/Case3Dto.java
@@ -16,23 +16,23 @@ import org.seedstack.business.api.interfaces.assembler.MatchingEntityId;
  */
 public class Case3Dto {
 
-    String firstName;
+    String customerName;
 
-    String lastName;
+    String orderItem;
 
-    public Case3Dto(String firstName, String lastName) {
-        this.firstName = firstName;
-        this.lastName = lastName;
+    public Case3Dto(String customerName, String orderItem) {
+        this.customerName = customerName;
+        this.orderItem = orderItem;
     }
 
-    @MatchingEntityId(index = 0)
-    public String getFirstName() {
-        return firstName;
+    @MatchingEntityId(typeIndex = 0)
+    public String getCustomerName() {
+        return customerName;
     }
 
-    @MatchingEntityId(index = 1)
-    public String getLastName() {
-        return lastName;
+    @MatchingEntityId(typeIndex = 1)
+    public String getOrderItem() {
+        return orderItem;
     }
 
 }

--- a/core/src/test/java/org/seedstack/business/core/interfaces/assembler/resolver/sample/Case4Dto.java
+++ b/core/src/test/java/org/seedstack/business/core/interfaces/assembler/resolver/sample/Case4Dto.java
@@ -12,9 +12,9 @@ package org.seedstack.business.core.interfaces.assembler.resolver.sample;
 import org.seedstack.business.api.interfaces.assembler.MatchingEntityId;
 
 /**
- * Case 4: The first name and last name are mapped to a {@literal Pair<String, String>} in the constructor.
+ * Case 4: The first name and last name are mapped to a {@code Pair&lt;String, String&gt;} in the constructor.
  *
- * @author Pierre Thirouin <pierre.thirouin@ext.mpsa.com>
+ * @author pierre.thirouin@ext.mpsa.com
  */
 public class Case4Dto {
 
@@ -22,9 +22,15 @@ public class Case4Dto {
 
     String lastName;
 
-    public Case4Dto(String firstName, String lastName) {
+    String orderItem;
+
+    String orderDescription;
+
+    public Case4Dto(String firstName, String lastName, String orderItem, String orderDescription) {
         this.firstName = firstName;
         this.lastName = lastName;
+        this.orderItem = orderItem;
+        this.orderDescription = orderDescription;
     }
 
     @MatchingEntityId(index = 0, typeIndex = 0)
@@ -32,8 +38,18 @@ public class Case4Dto {
         return firstName;
     }
 
-    @MatchingEntityId(index = 0, typeIndex = 1)
+    @MatchingEntityId(index = 1, typeIndex = 0)
     public String getLastName() {
         return lastName;
+    }
+
+    @MatchingEntityId(index = 0, typeIndex = 1)
+    public String getOrderItem() {
+        return orderItem;
+    }
+
+    @MatchingEntityId(index = 1, typeIndex = 1)
+    public String getOrderDescription() {
+        return orderDescription;
     }
 }

--- a/specs/src/main/java/org/seedstack/business/api/Tuples.java
+++ b/specs/src/main/java/org/seedstack/business/api/Tuples.java
@@ -16,6 +16,7 @@ import org.javatuples.*;
 import org.seedstack.seed.core.utils.SeedCheckUtils;
 
 import java.lang.reflect.ParameterizedType;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
@@ -27,6 +28,42 @@ import java.util.List;
 public final class Tuples {
 
     private Tuples() {
+    }
+
+    /**
+     * Transforms a list of object into a tuple. Does not work array of more than ten element.
+     *
+     * @param objects the list of object
+     * @param <TUPLE> the tuple type
+     * @return a tuple
+     * @throws org.seedstack.seed.core.api.SeedException if the array length is greater than 10
+     */
+    @SuppressWarnings("unchecked")
+    public static <TUPLE extends Tuple> TUPLE  create(List<?> objects) {
+        SeedCheckUtils.checkIf(objects.size() <= 10, "Can't create a Tuple of more than ten element.");
+
+        Class<? extends Tuple> tupleClass = classOfTuple(objects.toArray(new Object[objects.size()]));
+
+        return  (TUPLE) Reflection
+                .staticMethod("fromCollection")
+                .withReturnType(tupleClass)
+                .withParameterTypes(Collection.class)
+                .in(tupleClass).invoke(objects);
+    }
+
+    /**
+     * Transforms an array of object into a tuple. Does not work array of more than ten element.
+     *
+     * @param objects the array of object
+     * @param <TUPLE> the tuple type
+     * @return a tuple
+     * @throws org.seedstack.seed.core.api.SeedException if the array length is greater than 10
+     */
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    public static <TUPLE extends Tuple> TUPLE  create(Object firstObject, Object... objects) {
+        List list = Lists.newArrayList(firstObject);
+        list.addAll(Arrays.asList(objects));
+        return (TUPLE) create(list);
     }
 
     /**
@@ -45,19 +82,6 @@ public final class Tuples {
     }
 
     /**
-     * Transforms an array of object into a tuple. Does not work array of more than ten element.
-     *
-     * @param objects the array of object
-     * @param <TUPLE> the tuple type
-     * @return a tuple
-     * @throws org.seedstack.seed.core.api.SeedException if the array length is greater than 10
-     */
-    @SuppressWarnings({ "unchecked", "rawtypes" })
-    public static <TUPLE extends Tuple> TUPLE  create(Object... objects) {
-        return (TUPLE) createTupleFromList((List) Lists.newArrayList(objects));
-    }
-
-    /**
      * Transforms a list of object into a tuple. Does not work array of more than ten element.
      *
      * @param objects the list of object
@@ -72,25 +96,8 @@ public final class Tuples {
         return  create(objects);
     }
 
-    /**
-     * Transforms a list of object into a tuple. Does not work array of more than ten element.
-     *
-     * @param objects the list of object
-     * @param <TUPLE> the tuple type
-     * @return a tuple
-     * @throws org.seedstack.seed.core.api.SeedException if the array length is greater than 10
-     */
-    @SuppressWarnings("unchecked")
-    public static <TUPLE extends Tuple> TUPLE  create(List<Object> objects) {
-        SeedCheckUtils.checkIf(objects.size() <= 10, "Can't create a Tuple of more than ten element.");
-
-        Class<? extends Tuple> tupleClass = classOfTuple(objects.toArray(new Object[objects.size()]));
-
-        return  (TUPLE) Reflection
-                .staticMethod("fromCollection")
-                .withReturnType(tupleClass)
-                .withParameterTypes(Collection.class)
-                .in(tupleClass).invoke(objects);
+    public static Class<? extends Tuple> classOfTuple(List<?> objects) {
+        return classOfTuple(objects.toArray());
     }
 
     /**

--- a/specs/src/main/java/org/seedstack/business/api/interfaces/assembler/MatchingEntityId.java
+++ b/specs/src/main/java/org/seedstack/business/api/interfaces/assembler/MatchingEntityId.java
@@ -16,18 +16,85 @@ import java.lang.annotation.Target;
 
 
 /**
- * This annotation is a marker allowing {@linkplain Assemblers} to retrieve the right AggregateRoot
- * when retrieving from the persistence. This describes the entityId.
- * <p/>
- * When defining DTO, developers can annotate methods that match with entityId with {@link MatchingEntityId}.
- * <p/>
- *  Doing this will allow {@link Assemblers} to automatically retrieve the Entity by the representation of entityId.
- * <p/>
- * This annotation serves as gateway between Aggregate Root and DTO. 
- * 
- * for doing the match between representation/dto methods 
- * to id ValueObject constructor parameters.
- * 
+ * This annotation allows the use of the {@code fromRepository()} method of the assembler DSL. If you don't use
+ * this DSL feature, this annotated is unnecessary.
+ * <p>
+ * It binds the DTO annotated method to the aggregate root id. If the id is a value object, it binds the method
+ * to one of the constructor parameters. This allows the assembler DSL to find (or create) the aggregate root id
+ * in order to load the aggregate root from the repository.
+ * </p>
+ * <p>
+ * It also handle the case of a DTO assembled from a tuple of aggregate roots.
+ * </p>
+ * Case 1: Basic use case.
+ * <pre>
+ * public class OrderDto {
+ *
+ *     {@literal @}MatchingEntityId
+ *     public int getId() {...}
+ * }
+ *
+ * public class OrderAssembler extends BaseTupleAssembler&lt;Order, OrderDto&gt; { ... }
+ *
+ * public class Order {
+ *
+ *     private int orderId;
+ *
+ *     public Integer getEntityId() {
+ *         return orderId;
+ *     }
+ * }
+ * </pre>
+ * Case 1: Basic use case.
+ * <pre>
+ * public class CustomerDto {
+ *
+ *     {@literal @}MatchingEntityId(index = 0)
+ *     public String getFirstName() {...}
+ *
+ *     {@literal @}MatchingEntityId(index = 1)
+ *     public String getLastName() {...}
+ *
+ *     // No need for annotation here as the birth date is not part of the customer id
+ *     public Date getBirthDate() {...}
+ * }
+ *
+ * public class RecipeAssembler extends BaseAssembler&lt;Customer, CustomerDto&gt; { ... }
+ *
+ * public class CustomerId {
+ *     public CustomerId(String firstName, String lastName) {...}
+ * }
+ * </pre>
+ * Case 2: The DTO is an assembly of multiple aggregates.
+ * <pre>
+ * public class RecipeDto {
+ *
+ *     {@literal @}MatchingEntityId(index = 0, typeIndex = 0)
+ *     public String getCustomerFirstName() {...}
+ *
+ *     {@literal @}MatchingEntityId(index = 1, typeIndex = 0)
+ *     public String getCustomerLastName() {...}
+ *
+ *     {@literal @}MatchingEntityId(typeIndex = 1) // no need for index as OrderId is not a value object
+ *     public int getOrderId() {...}
+ * }
+ *
+ * public class RecipeAssembler extends BaseTupleAssembler&lt;Pair&lt;Customer, Order&gt;, RecipeDto&gt; { ... }
+ *
+ * public class CustomerId {
+ *     public CustomerId(String firstName, String lastName) {...}
+ * }
+ *
+ * public class Order {
+ *
+ *     private int orderId;
+ *
+ *     public Integer getEntityId() {
+ *         return orderId;
+ *     }
+ * }
+ * </pre>
+ *
  * @author epo.jemba@ext.mpsa.com
  *
  */
@@ -36,28 +103,21 @@ import java.lang.annotation.Target;
 public @interface MatchingEntityId {
 
     /**
-     * The index of the current matching field. Inside a single type.
+     * If the aggregate root id is composite, i.e it is a value object, this method indicates
+     * constructor parameter of the value object associated to the annotated method.
+     *
+     * @return the parameter index in the id constructor.
      */
 	int index() default -1;
 
     /**
-     * In case of Tuple of Aggregate Roots, this field indicate the index number of the associated Root inside the Tuple.
-     * <p/>
-     * For instance, in case of
-     * <pre>
-     * public class UseCase1Assembler extends BaseTupleAssembler<Quartet<Activation, Customer, Order, Product>, UseCase1Representation> {
-     *    ...
-     * }
-     * </pre>
-     * A field inside a DTO that matches Customer will look like:
-     * <pre>
-     * {@literal @}MatchingEntityId(typeIndex=1)
-     * public String getCustomer() {
-     *     return customer;
-     * }
-     * </pre>
+     * When using a tuple assembler, i.e. when assembling a DTO to tuple of aggregate roots.
+     * This index indicates to which aggregate root this id belongs.
      *
-     * @return the index of the type inside Tuple starting by 0.
+     * @return the aggregate index
+     *
+     * @see BaseTupleAssembler
      */
     int typeIndex() default -1;
+
 }

--- a/specs/src/main/java/org/seedstack/business/api/interfaces/assembler/MatchingFactoryParameter.java
+++ b/specs/src/main/java/org/seedstack/business/api/interfaces/assembler/MatchingFactoryParameter.java
@@ -16,8 +16,59 @@ import java.lang.annotation.Target;
 
 
 /**
- * This annotation serves for doing the match between representation/dto methods
- * to factory create method parameters. 
+ * This annotation allows the use of the {@code fromFactory()} method of the assembler DSL. If you don't use
+ * this DSL feature, this annotated is unnecessary.
+ * <p>
+ * It binds the DTO's annotated method to one parameter of a factory method used to create the
+ * assembled aggregate.
+ * </p>
+ * <p>
+ * It also handle the case of a DTO assembled from a tuple of aggregate roots.
+ * </p>
+ * Case 1: Basic use case.
+ * <pre>
+ * public class CustomerDto {
+ *
+ *     {@literal @}MatchingFactoryParameter(index = 0)
+ *     public String getName() {...}
+ *
+ *     {@literal @}MatchingFactoryParameter(index = 1)
+ *     public Date getBirthDate() {...}
+ *
+ *     // No need for annotation here as the address is not part of the factory method
+ *     public Address getAddress() {...}
+ * }
+ *
+ * public class RecipeAssembler extends BaseAssembler&lt;Customer, CustomerDto&gt; { ... }
+ *
+ * public class CustomerFactory {
+ *     public Customer createCustomer(String name, Date birthDate);
+ * }
+ * </pre>
+ * Case 2: The DTO is an assembly of multiple aggregates.
+ * <pre>
+ * public class RecipeDto {
+ *
+ *     {@literal @}MatchingFactoryParameter(index = 0, typeIndex = 0)
+ *     public String getCustomerName() {...}
+ *
+ *     {@literal @}MatchingFactoryParameter(index = 1, typeIndex = 0)
+ *     public Date getCustomerBirthDate() {...}
+ *
+ *     {@literal @}MatchingFactoryParameter(index = 0, typeIndex = 1)
+ *     public int getOrderId() {...}
+ * }
+ *
+ * public class RecipeAssembler extends BaseTupleAssembler&lt;Pair&lt;Customer, Order&gt;, RecipeDto&gt; { ... }
+ *
+ * public class CustomerFactory {
+ *     Customer createCustomer(String name, Date birthDate);
+ * }
+ *
+ * public class OrderFactory {
+ *     Customer createOrder(int orderId);
+ * }
+ * </pre>
  *  
  * @author epo.jemba@ext.mpsa.com
  *
@@ -27,16 +78,19 @@ import java.lang.annotation.Target;
 public @interface MatchingFactoryParameter {
 
     /**
+     * Indicates which factory parameter the annotated method match.
+     *
      * @return the parameter index in the factory method.
      */
 	int index() default -1;
 
     /**
-     * When using a BaseTupleAssembler, this type index is used to indicate to in
+     * When using a tuple assembler, i.e. when assembling a DTO to tuple of aggregate roots.
+     * This index indicates for which aggregate root this factory parameter is used.
      *
-     * @return the entity index in the tuple.
+     * @return the aggregate index
      *
      * @see BaseTupleAssembler
      */
-    int typeIndex () default -1;
+    int typeIndex() default -1;
 }

--- a/specs/src/main/java/org/seedstack/business/api/interfaces/assembler/dsl/BaseAggAssemblerProvider.java
+++ b/specs/src/main/java/org/seedstack/business/api/interfaces/assembler/dsl/BaseAggAssemblerProvider.java
@@ -14,11 +14,32 @@ import org.javatuples.Tuple;
 import org.seedstack.business.api.domain.AggregateRoot;
 
 /**
-* @author Pierre Thirouin <pierre.thirouin@ext.mpsa.com>
-*/
+ * Provides methods to specify the aggregate class to which aggregate root (or tuple of aggregate root) assemble.
+ *
+ * @author Pierre Thirouin <pierre.thirouin@ext.mpsa.com>
+ */
 public interface BaseAggAssemblerProvider {
 
+    /**
+     * Assembles to an aggregate root.
+     *
+     * @param aggregateRootClass the aggregate root class
+     * @param <A>                the type of aggregate root
+     * @return the assembler DSL to assemble an aggregate root
+     */
     <A extends AggregateRoot<?>> AggAssemblerWithRepoProvider<A> to(Class<A> aggregateRootClass);
 
-    <T extends Tuple> TupleAggAssemblerWithRepoProvider<T> to(T aggregateRootTuple);
+    /**
+     * Assembles to a tuple of aggregate roots.
+     * <p>
+     * The parameters are cut in three in order to not conflict with the non tuple method.
+     * </p>
+     *
+     * @param firstAggregateClass   the first aggregate root class of the tuple
+     * @param secondAggregateClass  the second class
+     * @param otherAggregateClasses and the rest
+     * @param <T>                   The tuple type
+     * @return the assembler DSL to assemble a tuple of aggregate roots
+     */
+    <T extends Tuple> TupleAggAssemblerWithRepoProvider<T> to(Class<? extends AggregateRoot<?>> firstAggregateClass, Class<? extends AggregateRoot<?>> secondAggregateClass, Class<? extends AggregateRoot<?>>... otherAggregateClasses);
 }

--- a/specs/src/main/java/org/seedstack/business/api/interfaces/assembler/resolver/ParameterHolder.java
+++ b/specs/src/main/java/org/seedstack/business/api/interfaces/assembler/resolver/ParameterHolder.java
@@ -13,6 +13,7 @@ package org.seedstack.business.api.interfaces.assembler.resolver;
  * This class holds the parameter of a method. It is used to collect parameters and then match them to a method.
  *
  * @author Pierre Thirouin <pierre.thirouin@ext.mpsa.com>
+ * @see org.seedstack.business.api.interfaces.assembler.resolver.DtoInfoResolver
  */
 public interface ParameterHolder {
 
@@ -20,20 +21,20 @@ public interface ParameterHolder {
      * Adds a parameter value at its position in the expected method.
      *
      * @param source the source used to get the value. Used for debugging information.
-     * @param index the position in the method
-     * @param value the parameter value
+     * @param index  the position in the method
+     * @param value  the parameter value
      */
     void put(String source, int index, Object value);
 
     /**
-     * Adds a parameter value in a tuple at its position in the expected method.
+     * Adds a parameter value for the specified aggregate root at its position in the expected method.
      *
-     * @param source the source used to get the value. Used for debugging information.
-     * @param index the position in the method
-     * @param tupleIndex the position in the tuple
-     * @param value the parameter value
+     * @param sourceMethod   the source method used to get the value. Used for debugging information.
+     * @param aggregateIndex the index corresponding to the aggregate root position in the tuple of aggregate roots.
+     * @param index          the position in the method
+     * @param value          the parameter value
      */
-    void put(String source, int index, int tupleIndex, Object value);
+    void put(String sourceMethod, int aggregateIndex, int index, Object value);
 
     /**
      * Gives the ordered list of parameters.
@@ -43,16 +44,52 @@ public interface ParameterHolder {
     Object[] parameters();
 
     /**
-     * Gives the ordered list of parameters.
+     * Gives the ordered list of parameters for specified index.
+     *
+     * @param aggregateIndex the index corresponding to the aggregate root position in the tuple of aggregate roots.
+     * @return the array of parameters
+     */
+    Object[] parametersOfAggregateRoot(int aggregateIndex);
+
+    /**
+     * Gives the first parameter of the first aggregate.
      *
      * @return array of parameters
      */
-    Object first();
+    Object uniqueElement();
 
     /**
-     * Indicates whether the holder contains parameters or not.
+     * Gives the first parameter of the specified aggregate.
+     *
+     * @param aggregateIndex the index corresponding to the aggregate root position in the tuple of aggregate roots.
+     * @return array of parameters
+     */
+    Object uniqueElementForAggregateRoot(int aggregateIndex);
+
+    /**
+     * Indicates whether the holder contains parameters. If there
+     * <p>
+     * This is equivalent to {@code isEmptyForAggregateRoot(-1) || isEmptyForAggregateRoot(0)}.
+     * If there is only one aggregate root, the index is -1, otherwise it starts at 0.
+     * </p>
      *
      * @return true if the holder doesn't contain parameters, false otherwise
      */
     boolean isEmpty();
+
+    /**
+     * Indicates whether the holder contains parameters for the aggregate root at the
+     * aggregateIndex position in the tuple.
+     * <p>
+     * It starts at the index 0, or -1 if there is only one aggregate defined.
+     * </p>
+     * <p>
+     * It checks if there is at least one aggregate defined and if the first aggregate
+     * as at least one parameter.
+     * </p>
+     *
+     * @param aggregateIndex the index corresponding to the aggregate root position in the tuple of aggregate roots.
+     * @return true if the holder doesn't contain parameters, false otherwise
+     */
+    boolean isEmptyForAggregateRoot(int aggregateIndex);
 }

--- a/specs/src/main/resources/META-INF/errors/org.seedstack.business.api.domain.DomainErrorCodes.properties
+++ b/specs/src/main/resources/META-INF/errors/org.seedstack.business.api.domain.DomainErrorCodes.properties
@@ -10,8 +10,8 @@
 
 ENTITY_WITHOUT_IDENTITY_ISSUE.message=Missing identity for ${className} entity.
 AGGREGATE_ROOT_CREATION_ISSUE.message=A creation issue occurred for ${aggregateRoot}.
-DOMAIN_OBJECT_CONSTRUCTOR_NOT_FOUND.message = DomainObject constructor not found for: ${domainObject}, with parameters: ${parameters}
-DOMAIN_OBJECT_CONSTRUCTOR_NOT_FOUND.fix = Please check your DomainObject ${domainObject} for existing construction using parameters ${parameters}
+DOMAIN_OBJECT_CONSTRUCTOR_NOT_FOUND.message = Constructor not found for: ${domainObject}, with parameters: ${parameters}
+DOMAIN_OBJECT_CONSTRUCTOR_NOT_FOUND.fix = Please check ${domainObject} for existing constructor using parameters ${parameters}
 UNABLE_TO_INVOKE_CONSTRUCTOR.message = Unable to invoke constructor: ${constructor}, for DomainObject: ${domainObject}, using parameters ${parameters}
 AMBIGUOUS_CONSTRUCTOR_FOUND.message = Ambiguous constructor found for: ${constructor1}, ${constructor2} ,of object: ${object}
 AMBIGUOUS_CONSTRUCTOR_FOUND.fix = Please check for null parameters or ambiguous constructor with matching primitives and types for parameters: ${parameters}

--- a/specs/src/test/java/org/seedstack/business/api/TuplesTest.java
+++ b/specs/src/test/java/org/seedstack/business/api/TuplesTest.java
@@ -9,6 +9,7 @@
  */
 package org.seedstack.business.api;
 
+import com.google.common.collect.Lists;
 import com.google.inject.util.Types;
 import org.assertj.core.api.Assertions;
 import org.javatuples.Pair;
@@ -17,6 +18,7 @@ import org.javatuples.Tuple;
 import org.junit.Test;
 
 import java.lang.reflect.Type;
+import java.util.List;
 
 /**
  * Tests the helper class {@link org.seedstack.business.api.Tuples}.
@@ -26,16 +28,28 @@ import java.lang.reflect.Type;
 public class TuplesTest {
 
     @Test
-    public void testCreateTupleFromList() {
-        Tuple tuple = Tuples.create(String.class, Long.class);
+    public void testCreateTupleFromVarArgs() {
+
         Pair<Integer, String> pair = Tuples.create(10, "foo");
         Assertions.assertThat((Iterable<?>) pair).isEqualTo(new Pair<Integer, String>(10, "foo"));
+
+        Tuple tuple = Tuples.create(String.class, Long.class);
         Assertions.assertThat((Iterable<?>) tuple).isInstanceOf(Pair.class);
         Assertions.assertThat(tuple.containsAll(String.class, Long.class)).isTrue();
         Assertions.assertThat(tuple.getSize()).isEqualTo(2);
 
         tuple = Tuples.create(String.class, Long.class, Float.class);
         Assertions.assertThat((Iterable<?>) tuple).isInstanceOf(Triplet.class);
+    }
+
+    @Test
+    public void testCreateTupleFromList() {
+        List<?> classes = Lists.newArrayList(String.class, Long.class);
+        Tuple tuple = Tuples.create(classes);
+
+        Assertions.assertThat((Iterable<?>) tuple).isInstanceOf(Pair.class);
+        Assertions.assertThat(tuple.containsAll(String.class, Long.class)).isTrue();
+        Assertions.assertThat(tuple.getSize()).isEqualTo(2);
     }
 
     @Test


### PR DESCRIPTION
This PR adds the full support for tuples in the DSL. It also fix the `ParameterHolder` for the "normal case".

I also added a new javadoc on the annotations [MatchingEntityId](https://github.com/seedstack/business/compare/seedstack:master...pith:assembler-dsl-with-tuple%2314?expand=1#diff-6ea8086c19373ff28f6aa7e492c4b151R19) and [MatchingFactoryParameter](https://github.com/seedstack/business/compare/seedstack:master...pith:assembler-dsl-with-tuple%2314?expand=1#diff-077f1176896943544ad3a074a7379f3aR19)
