### PR TITLE
Remove the fallback to ModelMapper in the DSL

### DIFF
--- a/core/src/it/java/org/seedstack/business/assembler/dsl/AssemblerDslWithTupleIT.java
+++ b/core/src/it/java/org/seedstack/business/assembler/dsl/AssemblerDslWithTupleIT.java
@@ -14,6 +14,7 @@ import org.javatuples.Pair;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.seedstack.business.api.domain.Repository;
+import org.seedstack.business.api.interfaces.assembler.AssemblerTypes;
 import org.seedstack.business.api.interfaces.assembler.FluentAssembler;
 import org.seedstack.business.api.interfaces.assembler.dsl.AggregateNotFoundException;
 import org.seedstack.business.internal.interfaces.assembler.dsl.fixture.customer.*;
@@ -45,7 +46,7 @@ public class AssemblerDslWithTupleIT {
     public void testAssembleFromFactory() {
         Recipe recipe = new Recipe("customer1", "luke", "order1", "light saber");
 
-        Pair<Order, Customer> orderCustomerPair = fluently.merge(recipe).into(Order.class, Customer.class).fromFactory();
+        Pair<Order, Customer> orderCustomerPair = fluently.merge(recipe).with(AssemblerTypes.MODEL_MAPPER).into(Order.class, Customer.class).fromFactory();
 
         Assertions.assertThat(orderCustomerPair.getValue0()).isNotNull();
         Assertions.assertThat(orderCustomerPair.getValue0().getEntityId()).isEqualTo("order1");
@@ -68,7 +69,7 @@ public class AssemblerDslWithTupleIT {
 
         Pair<Order, Customer> orderCustomerPair = null;
         try {
-            orderCustomerPair = fluently.merge(recipe).into(Order.class, Customer.class).fromRepository().orFail();
+            orderCustomerPair = fluently.merge(recipe).with(AssemblerTypes.MODEL_MAPPER).into(Order.class, Customer.class).fromRepository().orFail();
         } catch (AggregateNotFoundException e) {
             fail();
         }
@@ -87,7 +88,7 @@ public class AssemblerDslWithTupleIT {
     public void testAssembleFromRepositoryOrFail() {
         Recipe recipe = new Recipe("customer1", "luke", "order1", "light saber");
         try {
-            fluently.merge(recipe).into(Order.class, Customer.class).fromRepository().orFail();
+            fluently.merge(recipe).with(AssemblerTypes.MODEL_MAPPER).into(Order.class, Customer.class).fromRepository().orFail();
             fail();
         } catch (AggregateNotFoundException e) {
             Assertions.assertThat(e).isNotNull();
@@ -98,7 +99,7 @@ public class AssemblerDslWithTupleIT {
     public void testAssembleFromRepositoryOrFactory() {
         Recipe recipe = new Recipe("customer1", "luke", "order1", "light saber");
 
-        Pair<Order, Customer> orderCustomerPair = fluently.merge(recipe).into(Order.class, Customer.class).fromRepository().orFromFactory();
+        Pair<Order, Customer> orderCustomerPair = fluently.merge(recipe).with(AssemblerTypes.MODEL_MAPPER).into(Order.class, Customer.class).fromRepository().orFromFactory();
 
         Assertions.assertThat(orderCustomerPair.getValue0()).isNotNull();
         Assertions.assertThat(orderCustomerPair.getValue0().getEntityId()).isEqualTo("order1");
@@ -115,7 +116,7 @@ public class AssemblerDslWithTupleIT {
         Customer customer = new Customer("customer1");
         customer.setName("lucky");
 
-        fluently.merge(new Recipe("customer1", "luke", "order1", "light saber")).into(order, customer);
+        fluently.merge(new Recipe("customer1", "luke", "order1", "light saber")).with(AssemblerTypes.MODEL_MAPPER).into(order, customer);
 
         Assertions.assertThat(order).isNotNull();
         Assertions.assertThat(customer).isNotNull();

--- a/core/src/it/java/org/seedstack/business/assembler/dsl/InternalRegistryIT.java
+++ b/core/src/it/java/org/seedstack/business/assembler/dsl/InternalRegistryIT.java
@@ -71,7 +71,7 @@ public class InternalRegistryIT {
 
     @Test
     public void testAssemblerOfWithDefaultAssembler() {
-        Assembler<?, ?> assembler = registry.assemblerOf(Order.class, OrderDto.class);
+        Assembler<?, ?> assembler = registry.assemblerOf(Order.class, OrderDto.class, ModelMapper.class);
         Assertions.assertThat(assembler).isNotNull();
         Assertions.assertThat(assembler).isInstanceOf(ModelMapperAssembler.class);
         Assertions.assertThat(assembler).isInstanceOf(DefaultModelMapperAssembler.class);
@@ -83,7 +83,7 @@ public class InternalRegistryIT {
     @Test
     public void testAssemblerOfTuple() {
         List<?> aggregateRootTuple = Lists.newArrayList(org.seedstack.business.internal.interfaces.assembler.dsl.fixture.customer.Order.class, Customer.class);
-        Assembler<?, ?> assembler = registry.tupleAssemblerOf((List<Class<? extends AggregateRoot<?>>>) aggregateRootTuple, Recipe.class);
+        Assembler<?, ?> assembler = registry.tupleAssemblerOf((List<Class<? extends AggregateRoot<?>>>) aggregateRootTuple, Recipe.class, ModelMapper.class);
         Assertions.assertThat(assembler).isNotNull();
     }
 

--- a/core/src/main/java/org/seedstack/business/internal/interfaces/assembler/dsl/InternalRegistry.java
+++ b/core/src/main/java/org/seedstack/business/internal/interfaces/assembler/dsl/InternalRegistry.java
@@ -28,11 +28,7 @@ import java.util.List;
 public interface InternalRegistry {
 
     /**
-     * Returns an BaseAssembler matching the given aggregate root class and the dto class.
-     * <p>
-     * If no assembler were created by the client developer, the method returns an
-     * {@link org.seedstack.business.core.interfaces.assembler.ModelMapperAssembler}.
-     * </p>
+     * Returns the Assembler matching the given aggregate root class and the dto class.
      *
      * @param aggregateRoot the aggregate root class.
      * @param dto           the dto class
@@ -41,7 +37,7 @@ public interface InternalRegistry {
     Assembler<?, ?> assemblerOf(Class<? extends AggregateRoot<?>> aggregateRoot, Class<?> dto);
 
     /**
-     * Returns an BaseAssembler matching the given aggregate root class and the dto class.
+     * Returns the Assembler matching the given aggregate root class and the dto class for the specified qualifier.
      *
      * @param aggregateRoot the aggregate root class.
      * @param dto           the dto class
@@ -50,23 +46,43 @@ public interface InternalRegistry {
      */
     Assembler<?, ?> assemblerOf(Class<? extends AggregateRoot<?>> aggregateRoot, Class<?> dto, @Nullable Annotation qualifier);
 
+    /**
+     * Returns the Assembler matching the given aggregate root class and the dto class for the specified qualifier.
+     *
+     * @param aggregateRoot the aggregate root class
+     * @param dto           the dto class
+     * @param qualifier     the assembler qualifier
+     * @return the assembler
+     */
     Assembler<?, ?> assemblerOf(Class<? extends AggregateRoot<?>> aggregateRoot, Class<?> dto, @Nullable Class<? extends Annotation> qualifier);
 
     /**
-     * Returns an BaseTupleAssembler matching the given list of aggregate root classes and the dto class.
-     * <p>
-     * If no assembler were created by the client developer, the method returns an
-     * {@link org.seedstack.business.core.interfaces.assembler.ModelMapperTupleAssembler}.
-     * </p>
+     * Returns the Assembler matching the given list of aggregate root classes and the dto class.
      *
-     * @param aggregateRootTuple a list of aggregate root classes.
+     * @param aggregateRootTuple a list of aggregate root classes
      * @param dto                the dto class
      * @return the assembler
      */
     Assembler<?, ?> tupleAssemblerOf(List<Class<? extends AggregateRoot<?>>> aggregateRootTuple, Class<?> dto);
 
+    /**
+     * Returns the Assembler matching the given list of aggregate root classes and the dto class for the specified qualifier.
+     *
+     * @param aggregateRootTuple a list of aggregate root classes
+     * @param dto                the dto class
+     * @param qualifier          the assembler qualifier
+     * @return the assembler
+     */
     Assembler<?, ?> tupleAssemblerOf(List<Class<? extends AggregateRoot<?>>> aggregateRootTuple, Class<?> dto, @Nullable Annotation qualifier);
 
+    /**
+     * Returns the Assembler matching the given list of aggregate root classes and the dto class for the specified qualifier.
+     *
+     * @param aggregateRootTuple a list of aggregate root classes
+     * @param dto                the dto class
+     * @param qualifier          the assembler qualifier
+     * @return  the assembler
+     */
     Assembler<?, ?> tupleAssemblerOf(List<Class<? extends AggregateRoot<?>>> aggregateRootTuple, Class<?> dto, @Nullable Class<? extends Annotation> qualifier);
 
     /**
@@ -88,7 +104,7 @@ public interface InternalRegistry {
      * @param domainObject the domain object produced by the factory
      * @return the factory
      * @throws java.lang.IllegalArgumentException if the passed domainObject does not implement
-     * {@link org.seedstack.business.api.domain.DomainObject}
+     *                                            {@link org.seedstack.business.api.domain.DomainObject}
      */
     Factory<?> defaultFactoryOf(Class<? extends DomainObject> domainObject);
 

--- a/core/src/main/java/org/seedstack/business/internal/interfaces/assembler/dsl/InternalRegistryInternal.java
+++ b/core/src/main/java/org/seedstack/business/internal/interfaces/assembler/dsl/InternalRegistryInternal.java
@@ -19,7 +19,6 @@ import org.seedstack.business.api.Tuples;
 import org.seedstack.business.api.domain.*;
 import org.seedstack.business.api.interfaces.assembler.Assembler;
 import org.seedstack.business.api.interfaces.assembler.AssemblerErrorCodes;
-import org.seedstack.business.api.interfaces.assembler.ModelMapper;
 import org.seedstack.business.internal.utils.BusinessReflectUtils;
 import org.seedstack.seed.core.api.Logging;
 import org.seedstack.seed.core.api.SeedException;
@@ -94,12 +93,10 @@ public class InternalRegistryInternal implements InternalRegistry {
                 o = (Assembler<?, ?>) getInstance(Assembler.class, qualifier, aggregateRoot, dto);
             } else if (qualifierClass != null) {
                 o = (Assembler<?, ?>) getInstance(Assembler.class, qualifierClass, aggregateRoot, dto);
-            }else {
+            } else {
                 o = (Assembler<?, ?>) getInstance(Assembler.class, aggregateRoot, dto);
             }
         } catch (ConfigurationException e) {
-            logger.trace("Unable to find a  base assembler for " + aggregateRoot + ", fallback on automatic assembler.", e);
-
             SeedException seedException = SeedException.createNew(AssemblerErrorCodes.UNABLE_TO_FIND_ASSEMBLER_WITH_QUALIFIER)
                     .put("aggregateRoot", aggregateRoot)
                     .put("dto", dto);
@@ -109,15 +106,10 @@ public class InternalRegistryInternal implements InternalRegistry {
             } else if (qualifierClass != null) {
                 seedException.put("qualifier", qualifierClass.getSimpleName());
                 throw seedException;
-            }
-
-            try {
-                o = (Assembler<?, ?>) getInstance(Assembler.class, ModelMapper.class, aggregateRoot, dto);
-            } catch (ConfigurationException e2) {
-                throw SeedException.wrap(e2, AssemblerErrorCodes.FAILED_TO_FALLBACK_TO_DEFAULT_ASSEMBLER)
+            } else {
+                throw SeedException.createNew(AssemblerErrorCodes.UNABLE_TO_FIND_ASSEMBLER)
                         .put("aggregateRoot", aggregateRoot)
-                        .put("dto", dto)
-                        .put("qualifier", ModelMapper.class.getSimpleName());
+                        .put("dto", dto);
             }
         }
         return o;

--- a/specs/src/main/java/org/seedstack/business/api/interfaces/assembler/AssemblerErrorCodes.java
+++ b/specs/src/main/java/org/seedstack/business/api/interfaces/assembler/AssemblerErrorCodes.java
@@ -16,5 +16,5 @@ import org.seedstack.seed.core.api.ErrorCode;
  */
 public enum  AssemblerErrorCodes implements ErrorCode {
     UNABLE_TO_FIND_ASSEMBLER_WITH_QUALIFIER,
-    FAILED_TO_FALLBACK_TO_DEFAULT_ASSEMBLER
+    UNABLE_TO_FIND_ASSEMBLER
 }

--- a/specs/src/main/resources/META-INF/errors/org.seedstack.business.api.interfaces.assembler.AssemblerErrorCodes.properties
+++ b/specs/src/main/resources/META-INF/errors/org.seedstack.business.api.interfaces.assembler.AssemblerErrorCodes.properties
@@ -9,7 +9,8 @@
 #
 
 UNABLE_TO_FIND_ASSEMBLER_WITH_QUALIFIER.message = No assembler found to assemble ${aggregateRoot} into ${dto} with the qualifier ${qualifier}.
-UNABLE_TO_FIND_ASSEMBLER_WITH_QUALIFIER.fix = Please make sure that you have created an Assembler with this qualifier or that you have annotated ${dto} with @DtoOf(...).
+UNABLE_TO_FIND_ASSEMBLER_WITH_QUALIFIER.fix = Please make sure that you have created an Assembler with this qualifier. Or that you have annotated ${dto} with @DtoOf(...) if you use a default assembler.
 
-FAILED_TO_FALLBACK_TO_DEFAULT_ASSEMBLER.message = Failed to fallback on the default assembler with the ${qualifier} qualifier.
-FAILED_TO_FALLBACK_TO_DEFAULT_ASSEMBLER.fix = Please make sure that you have not define your own assembler. If you have created your own assembler don't use the default one.
+UNABLE_TO_FIND_ASSEMBLER.message = No assembler found to assemble ${aggregateRoot} into ${dto}.
+UNABLE_TO_FIND_ASSEMBLER.fix = Please make sure that you have created an Assembler. Or passed to the DSL the assembler's qualifier you want to use.
+


### PR DESCRIPTION
We should not chose the default assembler to which fallback. Because we don't want to break our users if we change our preferred mapper.
