### PR TITLE
Fix default assembler bindings

### DIFF
--- a/core/src/main/java/org/seedstack/business/internal/DefaultAssemblerCollector.java
+++ b/core/src/main/java/org/seedstack/business/internal/DefaultAssemblerCollector.java
@@ -1,0 +1,91 @@
+/**
+ * Copyright (c) 2013-2015 by The SeedStack authors. All rights reserved.
+ *
+ * This file is part of SeedStack, An enterprise-oriented full development stack.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.seedstack.business.internal;
+
+import com.google.common.reflect.TypeToken;
+import org.javatuples.Tuple;
+import org.seedstack.business.api.Tuples;
+import org.seedstack.business.api.domain.AggregateRoot;
+import org.seedstack.business.api.interfaces.assembler.Assembler;
+import org.seedstack.business.api.interfaces.assembler.DtoOf;
+import org.seedstack.business.core.interfaces.assembler.ModelMapperAssembler;
+import org.seedstack.business.internal.strategy.GenericBindingStrategy;
+import org.seedstack.business.internal.strategy.api.BindingStrategy;
+import org.seedstack.business.internal.strategy.api.ProviderFactory;
+
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Collects the binding strategies for default assemblers.
+ *
+ * @author pierre.thirouin@ext.mpsa.com (Pierre Thirouin)
+ */
+class DefaultAssemblerCollector {
+
+    private final Collection<Class<?>> defaultAssemblersClasses;
+
+    /**
+     * Constructor.
+     *
+     * @param defaultAssemblersClasses the default assembler classes to bind
+     */
+    public DefaultAssemblerCollector(Collection<Class<?>> defaultAssemblersClasses) {
+        this.defaultAssemblersClasses = defaultAssemblersClasses;
+    }
+
+    /**
+     * Provides the list of binding strategies for the default assemblers based
+     * on classes annotated by {@literal @}DtoOf.
+     *
+     * @param dtoClasses the DTO classes annotated by {@literal @}DtoOf
+     * @return collection of default assembler binding strategies
+     */
+    public Collection<BindingStrategy> collect(Collection<Class<?>> dtoClasses) {
+        // Contains pairs of aggregateClass/dtoClass
+        Set<Type[]> autoAssemblerGenerics = new HashSet<Type[]>();
+        // Contains pairs of aggregateTuple/dtoClass
+        Set<Type[]> autoTupleAssemblerGenerics = new HashSet<Type[]>();
+
+        // Extract pair of aggregateClass/dtoClass
+        for (Class<?> dtoClass : dtoClasses) {
+            DtoOf dtoOf = dtoClass.getAnnotation(DtoOf.class);
+            // Silently ignore bad arguments
+            if (dtoOf == null) {
+                continue;
+            }
+            if (dtoOf.value().length == 1) {
+                Class<? extends AggregateRoot<?>> aggregateClass = dtoOf.value()[0];
+                autoAssemblerGenerics.add(new Type[]{aggregateClass, dtoClass});
+            } else if (dtoOf.value().length > 1) {
+                autoTupleAssemblerGenerics.add(new Type[]{Tuples.typeOfTuple(dtoOf.value()), dtoClass});
+            }
+        }
+
+        Collection<BindingStrategy> bs = new ArrayList<BindingStrategy>();
+        // Each pairs of aggregateClass/dtoClass or aggregateTuple/dtoClass is bind to all the default assemblers
+        for (Class<?> defaultAssemblersClass : defaultAssemblersClasses) {
+            Class<?> aggregateType = TypeToken.of(defaultAssemblersClass).resolveType(defaultAssemblersClass.getTypeParameters()[0]).getRawType();
+
+            if (aggregateType.isAssignableFrom(Tuple.class) && !autoTupleAssemblerGenerics.isEmpty()) {
+                bs.add(new GenericBindingStrategy(autoTupleAssemblerGenerics, Assembler.class,
+                        defaultAssemblersClass, new ProviderFactory<ModelMapperAssembler>()));
+
+            } else if (!autoAssemblerGenerics.isEmpty()){
+                bs.add(new GenericBindingStrategy(autoAssemblerGenerics, Assembler.class,
+                        defaultAssemblersClass, new ProviderFactory<ModelMapperAssembler>()));
+            }
+        }
+        return bs;
+    }
+}

--- a/core/src/test/java/org/seedstack/business/internal/DefaultAssemblerCollectorTest.java
+++ b/core/src/test/java/org/seedstack/business/internal/DefaultAssemblerCollectorTest.java
@@ -1,0 +1,100 @@
+/**
+ * Copyright (c) 2013-2015 by The SeedStack authors. All rights reserved.
+ *
+ * This file is part of SeedStack, An enterprise-oriented full development stack.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.seedstack.business.internal;
+
+import com.google.common.collect.Lists;
+import org.assertj.core.api.Assertions;
+import org.junit.Before;
+import org.junit.Test;
+import org.powermock.reflect.Whitebox;
+import org.seedstack.business.api.domain.AggregateRoot;
+import org.seedstack.business.api.domain.base.BaseAggregateRoot;
+import org.seedstack.business.api.interfaces.assembler.AbstractBaseAssembler;
+import org.seedstack.business.api.interfaces.assembler.DtoOf;
+import org.seedstack.business.internal.strategy.api.BindingStrategy;
+
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * @author pierre.thirouin@ext.mpsa.com (Pierre Thirouin)
+ */
+public class DefaultAssemblerCollectorTest {
+
+    private DefaultAssemblerCollector underTest;
+
+    @Before
+    public void before() {
+        List<Class<?>> defaultAssemblers = new ArrayList<Class<?>>();
+        defaultAssemblers.add(DefaultAssemblerFixture1.class);
+        defaultAssemblers.add(DefaultAssemblerFixture2.class);
+        underTest = new DefaultAssemblerCollector(defaultAssemblers);
+    }
+
+    @Test
+    public void testCollect() {
+        Collection<BindingStrategy> strategies = underTest.collect(Lists.<Class<?>>newArrayList(Dto1.class, Dto2.class, Dto3.class));
+        Assertions.assertThat(strategies).hasSize(2); // 2 default assembler implementation
+        Collection<Type[]> typeVariables = Whitebox.getInternalState(strategies.iterator().next(), "typeVariables");
+        Assertions.assertThat(typeVariables).hasSize(3); // 3 dtos
+    }
+
+    @Test
+    public void testCollectIllegalArgument() {
+        Collection<BindingStrategy> strategies = underTest.collect(Lists.<Class<?>>newArrayList(Dto4.class));
+        Assertions.assertThat(strategies).isNotNull();
+        Assertions.assertThat(strategies).isEmpty();
+    }
+
+    private static class Agg1 extends BaseAggregateRoot<Integer> {
+        @Override
+        public Integer getEntityId() { return null; }
+    }
+
+    private static class Agg2 extends BaseAggregateRoot<Integer> {
+        @Override
+        public Integer getEntityId() { return null; }
+    }
+
+    @DtoOf(Agg1.class)
+    private static class Dto1 { }
+
+    @DtoOf(Agg1.class)
+    private static class Dto2 { }
+
+    @DtoOf(Agg2.class)
+    private static class Dto3 { }
+
+    private static class Dto4 { }
+
+    private static class DefaultAssemblerFixture1<A extends AggregateRoot<?>, D> extends AbstractBaseAssembler<A, D> {
+        @Override
+        public D assembleDtoFromAggregate(A sourceAggregate) { return null; }
+
+        @Override
+        public void assembleDtoFromAggregate(D targetDto, A sourceAggregate) { }
+
+        @Override
+        public void mergeAggregateWithDto(A targetAggregate, D sourceDto) { }
+    }
+
+    private static class DefaultAssemblerFixture2<A extends AggregateRoot<?>, D> extends AbstractBaseAssembler<A, D> {
+        @Override
+        public D assembleDtoFromAggregate(A sourceAggregate) { return null; }
+
+        @Override
+        public void assembleDtoFromAggregate(D targetDto, A sourceAggregate) { }
+
+        @Override
+        public void mergeAggregateWithDto(A targetAggregate, D sourceDto) { }
+    }
+}


### PR DESCRIPTION
Only one default assembler was bound by aggregate, even if there were multiple DTO for the aggregate.

The binding logic has been extract from the plugin for a better testability.
