### PR TITLE
Move next/prev logic from page to PaginatedView

### DIFF
--- a/specs/src/main/java/org/seedstack/business/api/interfaces/view/AbstractView.java
+++ b/specs/src/main/java/org/seedstack/business/api/interfaces/view/AbstractView.java
@@ -27,7 +27,7 @@ public abstract class AbstractView<Item> implements View<Item> {
     protected final long resultSize;
     protected final long resultViewOffset;
 
-    protected final int resultViewSize;
+    protected final long resultViewSize;
 
     /**
      * This constructor take a list of items that can potentially be huge.
@@ -39,11 +39,11 @@ public abstract class AbstractView<Item> implements View<Item> {
      * @param resultViewOffset offset inside the big list
      * @param resultViewSize   size of the view inside the big list
      */
-    public AbstractView(VirtualList<Item> items, long resultViewOffset, int resultViewSize) {
+    public AbstractView(VirtualList<Item> items, long resultViewOffset, long resultViewSize) {
         this.resultList = items;
         this.resultSize = items.size();
         this.resultViewOffset = resultViewOffset;
-        this.resultViewSize = resultViewOffset + resultViewSize > this.resultSize ? (int) (this.resultSize - resultViewOffset) : resultViewSize;
+        this.resultViewSize = resultViewOffset + resultViewSize > this.resultSize ? (this.resultSize - resultViewOffset) : resultViewSize;
     }
 
     /**
@@ -53,7 +53,7 @@ public abstract class AbstractView<Item> implements View<Item> {
      * @param resultViewOffset the result view offset
      * @param resultViewSize   the result view size
      */
-    public AbstractView(Result<Item> result, long resultViewOffset, int resultViewSize) {
+    public AbstractView(Result<Item> result, long resultViewOffset, long resultViewSize) {
         this(new VirtualList<Item>(result.getResult(), result.getOffset(), result.getFullSize()), resultViewOffset, resultViewSize);
     }
 
@@ -64,7 +64,7 @@ public abstract class AbstractView<Item> implements View<Item> {
      * @param resultViewOffset the result view offset
      * @param resultViewSize   the result view size
      */
-    public AbstractView(List<Item> list, long resultViewOffset, int resultViewSize) {
+    public AbstractView(List<Item> list, long resultViewOffset, long resultViewSize) {
         this(new VirtualList<Item>(list, 0, list.size()), resultViewOffset, resultViewSize);
     }
 
@@ -77,7 +77,7 @@ public abstract class AbstractView<Item> implements View<Item> {
      * @param resultViewOffset the result view offset
      * @param resultViewSize   the result view size
      */
-    public AbstractView(List<Item> items, long subListStart, long subListSize, long resultViewOffset, int resultViewSize) {
+    public AbstractView(List<Item> items, long subListStart, long subListSize, long resultViewOffset, long resultViewSize) {
         this(new VirtualList<Item>(items, subListStart, subListSize), resultViewOffset, resultViewSize);
     }
 

--- a/specs/src/main/java/org/seedstack/business/api/interfaces/view/ChunkedView.java
+++ b/specs/src/main/java/org/seedstack/business/api/interfaces/view/ChunkedView.java
@@ -31,7 +31,7 @@ public class ChunkedView<T> extends AbstractView<T> {
      * @param chunkOffset the chunk offset
      * @param chunkSize   the chunk size
      */
-    public ChunkedView(Result<T> items, long chunkOffset, int chunkSize) {
+    public ChunkedView(Result<T> items, long chunkOffset, long chunkSize) {
         super(items, chunkOffset, chunkSize);
     }
 
@@ -42,7 +42,7 @@ public class ChunkedView<T> extends AbstractView<T> {
      * @param chunkStart the chunk start
      * @param chunkSize  the chunk size
      */
-    public ChunkedView(List<T> items, int chunkStart, int chunkSize) {
+    public ChunkedView(List<T> items, long chunkStart, long chunkSize) {
         super(items, chunkStart, chunkSize);
     }
 
@@ -56,7 +56,7 @@ public class ChunkedView<T> extends AbstractView<T> {
     /**
      * @return the chunk size
      */
-    public int getChunkSize() {
+    public long getChunkSize() {
         return resultViewSize;
     }
 

--- a/specs/src/main/java/org/seedstack/business/api/interfaces/view/Page.java
+++ b/specs/src/main/java/org/seedstack/business/api/interfaces/view/Page.java
@@ -11,102 +11,42 @@ package org.seedstack.business.api.interfaces.view;
 
 /**
  * Abstraction of a page within a context page set context.
+ * Pages have:
  * <ul>
- * <li>Page have a capacity in term of number of element</li>
- * <li>Page have an actual number of element (needed for the last page of a set of page)</li>
- * <li>Total number of elements of the page set.</li>
+ *   <li>an index,</li>
+ *   <li>a capacity in term of number of element.</li>
  * </ul>
  *
  * @author epo.jemba@ext.mpsa.com
  */
 public class Page {
 
-    private final int index;
-    private final int capacity;
-    private final int numberOfElements;
-    private final long totalNumberOfElements;
+    private final long index;
+    private final long capacity;
 
     /**
-     * Create a new page at a certain index, with a certain capacity ,with a maximum number of element (=capacity) and a total
-     * number of elements to -1 (infinite).
-     * <p>
-     * with a number of element maximum.
-     * </p>
+     * Creates a new page at a certain index and a certain capacity.
      *
      * @param pageIndex the page index (start with 0)
      * @param capacity  the number of element
      */
-    public Page(int pageIndex, int capacity) {
+    public Page(long pageIndex, long capacity) {
         this.index = pageIndex;
         this.capacity = capacity;
-        this.numberOfElements = capacity;
-        this.totalNumberOfElements = -1;
     }
 
     /**
-     * Create a new page at a certain index, with a certain capacity ,with a certain number of element and a total
-     * number of elements to -1 (infinite).
-     *
-     * @param pageIndex        the page index (start with 0)
-     * @param capacity         the page capacity size
-     * @param numberOfElements the number of element
+     * @return the page index
      */
-    public Page(int pageIndex, int capacity, int numberOfElements) {
-        this.index = pageIndex;
-        this.capacity = capacity;
-        this.numberOfElements = numberOfElements;
-        this.totalNumberOfElements = -1;
-    }
-
-    /**
-     * Create a new page at a certain index, with a certain capacity ,with a certain number of element and fixed total
-     * number of elements.
-     *
-     * @param pageIndex             the page index (start with 0)
-     * @param capacity              the page capacity size
-     * @param numberOfElements      the actual number of element
-     * @param totalNumberOfElements the total number of element
-     */
-    public Page(int pageIndex, int capacity, int numberOfElements, long totalNumberOfElements) {
-        this.index = pageIndex;
-        this.capacity = capacity;
-        this.numberOfElements = numberOfElements;
-        this.totalNumberOfElements = totalNumberOfElements;
-    }
-
-    /**
-     * @return the index
-     */
-    public int getIndex() {
+    public long getIndex() {
         return index;
     }
 
     /**
-     * @return the capacity
+     * @return the capacity of the page
      */
-    public int getCapacity() {
+    public long getCapacity() {
         return capacity;
-    }
-
-    /**
-     * @return the number of element
-     */
-    public int getNumberOfElements() {
-        return numberOfElements;
-    }
-
-    /**
-     * @return the total number of element
-     */
-    public long getTotalNumberOfElements() {
-        return totalNumberOfElements;
-    }
-
-    /**
-     * @return the next page
-     */
-    public Page next() {
-        return new Page(index + 1, capacity, numberOfElements, totalNumberOfElements);
     }
 
     @Override

--- a/specs/src/main/java/org/seedstack/business/api/interfaces/view/PaginatedView.java
+++ b/specs/src/main/java/org/seedstack/business/api/interfaces/view/PaginatedView.java
@@ -34,7 +34,7 @@ public class PaginatedView<Item> extends AbstractView<Item> {
      * @param pageSize  the number of item per page
      * @param pageIndex the page index
      */
-    public PaginatedView(List<Item> items, int pageSize, long pageIndex) {
+    public PaginatedView(List<Item> items, long pageSize, long pageIndex) {
         super(items, pageIndex * pageSize, pageSize);
         this.pageIndex = pageIndex;
         this.pagesCount = countPages(pageSize, this.resultSize);
@@ -47,7 +47,7 @@ public class PaginatedView<Item> extends AbstractView<Item> {
      * @param pageSize  the number of item per page
      * @param pageIndex the page index
      */
-    public PaginatedView(Result<Item> result, int pageSize, long pageIndex) {
+    public PaginatedView(Result<Item> result, long pageSize, long pageIndex) {
         super(result, pageIndex * pageSize, pageSize);
         this.pageIndex = pageIndex;
         this.pagesCount = countPages(pageSize, this.resultSize);
@@ -72,23 +72,67 @@ public class PaginatedView<Item> extends AbstractView<Item> {
      * @param pageSize     the number of item per page
      * @param pageIndex    the page index
      */
-    public PaginatedView(List<Item> subList, long subListStart, long realListSize, int pageSize, long pageIndex) {
+    public PaginatedView(List<Item> subList, long subListStart, long realListSize, long pageSize, long pageIndex) {
         super(subList, subListStart, realListSize, pageIndex * pageSize, pageSize);
         this.pageIndex = pageIndex;
         this.pagesCount = countPages(pageSize, this.resultSize);
     }
 
-    private long countPages(int size, long totalItemsCount2) {
-        if (size == 0) {
+    private long countPages(long pageSize, long totalItems) {
+        if (pageSize == 0) {
             throw new IllegalArgumentException("View cannot be computed with a page size of 0");
         }
-        return (long) Math.ceil((double) totalItemsCount2 / size);
+        return (long) Math.ceil((double) totalItems / pageSize);
+    }
+
+    /**
+     * Indicates whether the current page has a next page
+     *
+     * @return true is the current page is not the last one, false otherwise
+     */
+    public boolean hasNext() {
+        return pageIndex + 1 < pagesCount;
+    }
+
+    /**
+     * Returns the next page if it exists.
+     *
+     * @return the next page or null if there is no last page
+     */
+    public Page next() {
+        if (hasNext()) {
+            return new Page(pageIndex + 1, resultViewSize);
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * Indicates whether the current page has a previous page.
+     *
+     * @return true is the current page is not the first one, false otherwise
+     */
+    public boolean hasPrev() {
+        return pageIndex > 0;
+    }
+
+    /**
+     * Returns the previous page if it exists.
+     *
+     * @return the next page or null if there is no last page
+     */
+    public Page prev() {
+        if (hasPrev()) {
+            return new Page(pageIndex - 1, resultViewSize);
+        } else {
+            return null;
+        }
     }
 
     /**
      * @return the number of item per page
      */
-    public int getPageSize() {
+    public long getPageSize() {
         return this.resultViewSize;
     }
 

--- a/specs/src/test/java/org/seedstack/business/api/interfaces/view/PageTest.java
+++ b/specs/src/test/java/org/seedstack/business/api/interfaces/view/PageTest.java
@@ -1,0 +1,104 @@
+/**
+ * Copyright (c) 2013-2015 by The SeedStack authors. All rights reserved.
+ *
+ * This file is part of SeedStack, An enterprise-oriented full development stack.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.seedstack.business.api.interfaces.view;
+
+import com.google.common.collect.Lists;
+import org.assertj.core.api.Assertions;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.seedstack.business.api.interfaces.finder.Result;
+
+import java.util.List;
+
+/**
+ * @author pierre.thirouin@ext.mpsa.com (Pierre Thirouin)
+ */
+public class PageTest {
+
+    @Test
+    public void test_paginated_view() {
+        List<String> strings = Lists.newArrayList("one", "two", "three", "four", "five");
+        Page page = new Page(0, 5);
+        Result<String> result = new Result<String>(strings, 0, 100);
+
+        PaginatedView<String> paginatedView = new PaginatedView<String>(result, page);
+        Assertions.assertThat(paginatedView.getPagesCount()).isEqualTo(20);
+        Assertions.assertThat(paginatedView.getPageIndex()).isEqualTo(0);
+        Assertions.assertThat(paginatedView.getPageSize()).isEqualTo(5);
+    }
+
+    @Test
+    public void test_paginated_view_page_navigation() {
+        List<String> strings = Lists.newArrayList("one", "two", "three", "four", "five");
+        Page page = new Page(0, 5);
+        Result<String> result = new Result<String>(strings, 0, 100);
+
+        // Test the first page
+        PaginatedView<String> paginatedView = new PaginatedView<String>(result, page);
+        Assertions.assertThat(paginatedView.hasPrev()).isFalse();
+        Assertions.assertThat(paginatedView.hasNext()).isTrue();
+        Assertions.assertThat(paginatedView.prev()).isNull();
+        Assertions.assertThat(paginatedView.next()).isNotNull();
+        Assertions.assertThat(paginatedView.next().getIndex()).isEqualTo(1);
+
+        // Navigate to the second page
+        paginatedView = new PaginatedView<String>(result, paginatedView.next());
+        Assertions.assertThat(paginatedView.hasPrev()).isTrue();
+        Assertions.assertThat(paginatedView.hasNext()).isTrue();
+        Assertions.assertThat(paginatedView.prev()).isNotNull();
+        Assertions.assertThat(paginatedView.prev().getIndex()).isEqualTo(0);
+
+        // test the last page
+        paginatedView = new PaginatedView<String>(result, new Page(19, 5));
+        Assertions.assertThat(paginatedView.hasPrev()).isTrue();
+        Assertions.assertThat(paginatedView.hasNext()).isFalse();
+        Assertions.assertThat(paginatedView.prev()).isNotNull();
+        Assertions.assertThat(paginatedView.next()).isNull();
+    }
+
+    @Test
+    public void test_paginated_view_edge_case() {
+        List<String> strings = Lists.newArrayList("one", "two", "three", "four", "five");
+        Page page = new Page(0, 10);
+        Result<String> result = new Result<String>(strings, 0, 92233720368547758L);
+
+        PaginatedView<String> paginatedView = new PaginatedView<String>(result, page);
+        Assertions.assertThat(paginatedView.getPagesCount()).isEqualTo(9223372036854776L);
+        Assertions.assertThat(paginatedView.getPageIndex()).isEqualTo(0);
+        Assertions.assertThat(paginatedView.getPageSize()).isEqualTo(10);
+    }
+
+    @Test
+    @Ignore("approximation error")
+    public void test_paginated_view_edge_case_max() {
+        List<String> strings = Lists.newArrayList("one", "two", "three", "four", "five");
+        Page page = new Page(0, 10);
+        // Long.MAX_VALUE = 9223372036854775807L
+        Result<String> result = new Result<String>(strings, 0, Long.MAX_VALUE);
+
+        PaginatedView<String> paginatedView = new PaginatedView<String>(result, page);
+        Assertions.assertThat(paginatedView.getPagesCount()).isEqualTo(922337203685477581L);
+        Assertions.assertThat(paginatedView.getPageIndex()).isEqualTo(0);
+        Assertions.assertThat(paginatedView.getPageSize()).isEqualTo(10);
+    }
+
+    @Test
+    public void test_paginated_view_edge_case_min() {
+        List<String> strings = Lists.newArrayList();
+        Page page = new Page(0, 10);
+        Result<String> result = new Result<String>(strings, 0, 0);
+
+        PaginatedView<String> paginatedView = new PaginatedView<String>(result, page);
+        Assertions.assertThat(paginatedView.getPagesCount()).isEqualTo(0);
+        Assertions.assertThat(paginatedView.getPageIndex()).isEqualTo(0);
+        Assertions.assertThat(paginatedView.getPageSize()).isEqualTo(0);
+    }
+
+}


### PR DESCRIPTION
Add the following methods in `PaginatedView`:

```
boolean hasNext()
boolean hasPrev()
Page next()
Page prev()
```

And remove these attributes from `Page`:

```
int numberOfElements
long totalNumberOfElements
```

They were not used, as the page is normally created before having these data.

```
Page -> Range -> finder -> Result -> PaginatedView 
```

Also transform all the `int` into `long`.
