### PR TITLE
Add exception on VirtualList for unbound index

### DIFF
--- a/jpa/src/it/java/org/seedstack/business/jpa/samples/finders/Dto1JpaRangeFinder.java
+++ b/jpa/src/it/java/org/seedstack/business/jpa/samples/finders/Dto1JpaRangeFinder.java
@@ -21,33 +21,32 @@ import java.util.Map;
 /**
  * criteria needed :
  * <li> param1 : string </li>
- * 
- * @author epo.jemba@ext.mpsa.com
  *
+ * @author epo.jemba@ext.mpsa.com
  */
 public class Dto1JpaRangeFinder extends BaseJpaRangeFinder<Dto1> {
-	
-	@Inject
-	EntityManager entityManager;
-	
-	@Override
+
+    @Inject
+    EntityManager entityManager;
+
+    @Override
     @SuppressWarnings("unchecked")
-	protected List<Dto1> computeResultList(Range range , Map<String,Object> criteria) {
-		Query query = entityManager.createQuery("select new " + Dto1.class.getName() + "(  a.entityId, a.field1, a.field2 , a.field3 , a.field4  )  from SampleSimpleJpaAggregateRoot a where a.field2 = :param1");
+    protected List<Dto1> computeResultList(Range range, Map<String, Object> criteria) {
+        Query query = entityManager.createQuery("select new " + Dto1.class.getName() + "(  a.entityId, a.field1, a.field2 , a.field3 , a.field4  )  from SampleSimpleJpaAggregateRoot a where a.field2 = :param1");
 
-		query.setFirstResult( (int)range.getOffset() );
-		query.setMaxResults ( range.getSize() );
-		
-		updateQuery(query , criteria);
-		
-		return (List<Dto1>)query.getResultList();
-	}
+        query.setFirstResult((int) range.getOffset());
+        query.setMaxResults((int) range.getSize());
 
-	@Override
-	protected long computeFullRequestSize(Map<String,Object> criteria) {
-		
-		Query query = entityManager.createQuery("select count(*) from SampleSimpleJpaAggregateRoot a where a.field2 = :param1");
-		updateQuery(query , criteria);
-		return (Long) query.getSingleResult();
-	}
+        updateQuery(query, criteria);
+
+        return (List<Dto1>) query.getResultList();
+    }
+
+    @Override
+    protected long computeFullRequestSize(Map<String, Object> criteria) {
+
+        Query query = entityManager.createQuery("select count(*) from SampleSimpleJpaAggregateRoot a where a.field2 = :param1");
+        updateQuery(query, criteria);
+        return (Long) query.getSingleResult();
+    }
 }

--- a/specs/src/main/java/org/seedstack/business/api/interfaces/finder/Range.java
+++ b/specs/src/main/java/org/seedstack/business/api/interfaces/finder/Range.java
@@ -17,7 +17,7 @@ package org.seedstack.business.api.interfaces.finder;
 public final class Range {
 
     private long offset;
-    private int size;
+    private long size;
 
     /**
      * Constructor.
@@ -25,7 +25,7 @@ public final class Range {
      * @param offset the range offset
      * @param size   the range size
      */
-    public Range(long offset, int size) {
+    public Range(long offset, long size) {
         this.offset = offset;
         this.size = size;
     }
@@ -40,7 +40,7 @@ public final class Range {
     /**
      * @return the range size
      */
-    public int getSize() {
+    public long getSize() {
         return size;
     }
 
@@ -51,7 +51,7 @@ public final class Range {
      * @param chunkSize   the chunk size
      * @return the range
      */
-    public static Range rangeFromChunkInfo(long chunkOffset, int chunkSize) {
+    public static Range rangeFromChunkInfo(long chunkOffset, long chunkSize) {
         return new Range(chunkOffset, chunkSize);
     }
 
@@ -62,7 +62,7 @@ public final class Range {
      * @param pageSize  the page size
      * @return the range
      */
-    public static Range rangeFromPageInfo(long pageIndex, int pageSize) {
+    public static Range rangeFromPageInfo(long pageIndex, long pageSize) {
         return new Range(pageIndex * pageSize, pageSize);
     }
 

--- a/specs/src/main/java/org/seedstack/business/api/interfaces/view/VirtualList.java
+++ b/specs/src/main/java/org/seedstack/business/api/interfaces/view/VirtualList.java
@@ -54,10 +54,10 @@ class VirtualList<T> {
     }
 
     /**
-     * Gets the sub list of item.
+     * Returns a portion of this list between the specified from, inclusive, and to, exclusive.
      *
-     * @param from the beginning of the list
-     * @param to   the end of the list
+     * @param from low endpoint (inclusive) of the subList
+     * @param to   high endpoint (exclusive) of the subList
      * @return the sub list of item
      */
     public List<T> subList(long from, long to) {
@@ -66,10 +66,11 @@ class VirtualList<T> {
             // subList takes a [from;to[ range
             checkRange(to - 1);
 
-            if (checkSubRange(from) && checkSubRange(to - 1)) {
-                // cannot exceed Integer.MAX_VALUE (checked by checkSubRange)
-                return subList.subList((int) (from - subListOffset), (int) (to - subListOffset));
-            }
+            // check if the data of the required sub list are available
+            assertSubRange(from, to - 1);
+
+            // cannot exceed Integer.MAX_VALUE (checked by checkSubRange)
+            return subList.subList((int) (from - subListOffset), (int) (to - subListOffset));
         }
 
         return new ArrayList<T>();
@@ -95,12 +96,26 @@ class VirtualList<T> {
     }
 
     /**
-     * Checks if the index is greater than the sub list offset and lower than the sum of the sub list offset and
-     * the sub list size.
+     * Checks if the index is greater than the sub list offset and lower than the sum of the sub
+     * list offset and the sub list size.
+     *
      * @param index the index to check
      * @return true if the index is not out of range, false otherwise
      */
     private boolean checkSubRange(long index) {
         return this.subListOffset <= index && index < (this.subListOffset + this.subList.size());
+    }
+
+    /**
+     * Asserts that the requested sub list is available in the virtual list. Otherwise it throws
+     * an IndexOutOfBoundsException.
+     *
+     * @param from the from index (inclusive)
+     * @param to   the to index (inclusive)
+     */
+    private void assertSubRange(long from, long to) {
+        if (!checkSubRange(from) || !checkSubRange(to)) {
+            throw new IndexOutOfBoundsException("Required data for the sub list [" + from + "," + (to + 1) + "[ have not been loaded in the virtual list.");
+        }
     }
 }

--- a/specs/src/test/java/org/seedstack/business/api/interfaces/view/PaginatedViewTest.java
+++ b/specs/src/test/java/org/seedstack/business/api/interfaces/view/PaginatedViewTest.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright (c) 2013-2015 by The SeedStack authors. All rights reserved.
+ *
+ * This file is part of SeedStack, An enterprise-oriented full development stack.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.seedstack.business.api.interfaces.view;
+
+import com.google.common.collect.Lists;
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+import org.seedstack.business.api.interfaces.finder.Result;
+
+import java.util.List;
+
+/**
+ * @author pierre.thirouin@ext.mpsa.com (Pierre Thirouin)
+ */
+public class PaginatedViewTest {
+
+    private PaginatedView<Integer> underTest;
+
+    @Test
+    public void test_paginated_view() {
+        // List of 5 items -- full size equals 10
+        List<Integer> integers = Lists.newArrayList(0,1,2,3,4);
+        Result<Integer> result = new Result<Integer>(integers, 0, 10);
+
+        // Get the first page
+        underTest = new PaginatedView<Integer>(result, new Page(0, 5));
+
+        Assertions.assertThat(underTest).isNotNull();
+        Assertions.assertThat(underTest.getPageIndex()).isEqualTo(0);
+        Assertions.assertThat(underTest.getView()).hasSize(5);
+        Assertions.assertThat(underTest.getResultSize()).isEqualTo(10);
+    }
+
+    @Test
+    public void test_paginated_view_incomplete_page() {
+        // List of 3 items -- full size equals 5
+        List<Integer> integers = Lists.newArrayList(0,1,2);
+        Result<Integer> result = new Result<Integer>(integers, 0, 3);
+
+        // Get a page with a capacity of 5 items
+        underTest = new PaginatedView<Integer>(result, new Page(0, 5));
+
+        Assertions.assertThat(underTest).isNotNull();
+        Assertions.assertThat(underTest.getPageIndex()).isEqualTo(0);
+        Assertions.assertThat(underTest.getView()).hasSize(3);
+    }
+
+    @Test(expected = IndexOutOfBoundsException.class)
+    public void test_paginated_view_incomplete_page2() {
+        // List of 3 items -- full size equals 5
+        List<Integer> integers = Lists.newArrayList(0,1,2);
+        Result<Integer> result = new Result<Integer>(integers, 0, 10);
+
+        // Get a page with a capacity of 5 items
+        underTest = new PaginatedView<Integer>(result, new Page(0, 5));
+        Assertions.assertThat(underTest.getView()).hasSize(3);
+    }
+
+    @Test
+    public void test_paginated_view_sub_list() {
+        // List of 10 items -- full size equals 10
+        List<Integer> integers = Lists.newArrayList(0,1,2,3,4,5,6,7,8,9);
+        Result<Integer> result = new Result<Integer>(integers, 0, 10);
+
+        // Get a page with a capacity of 5 items
+        underTest = new PaginatedView<Integer>(result, new Page(0, 5));
+
+        Assertions.assertThat(underTest).isNotNull();
+        Assertions.assertThat(underTest.getPageIndex()).isEqualTo(0);
+        Assertions.assertThat(underTest.getView()).hasSize(5);
+    }
+
+    @Test
+    public void test_paginated_view_last_page() {
+        // List of 3 items -- full size equals 13
+        List<Integer> integers = Lists.newArrayList(10,11,12);
+        Result<Integer> result = new Result<Integer>(integers, 10, 13);
+
+        // Get the last page
+        underTest = new PaginatedView<Integer>(result, new Page(1, 10));
+
+        Assertions.assertThat(underTest).isNotNull();
+        Assertions.assertThat(underTest.getPageIndex()).isEqualTo(1);
+        Assertions.assertThat(underTest.getView()).hasSize(3);
+    }
+}

--- a/specs/src/test/java/org/seedstack/business/api/interfaces/view/VirtualListTest.java
+++ b/specs/src/test/java/org/seedstack/business/api/interfaces/view/VirtualListTest.java
@@ -9,6 +9,7 @@
  */
 package org.seedstack.business.api.interfaces.view;
 
+import com.google.common.collect.Lists;
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
@@ -17,67 +18,70 @@ import java.util.List;
 
 import static junitparams.JUnitParamsRunner.$;
 
-
-//@RunWith(JUnitParamsRunner.class)
 public class VirtualListTest {
 
-	
-//	@Test
-//	@Parameters("listValues2")
-	public void check_get(  Integer index, Integer expectedValue  , VirtualList<Integer> virtualList ) 
-	{
-		Assertions.assertThat(virtualList.get(index)).isEqualTo(expectedValue);
-	}
-	@Test
-	public void getTests ()
-	{
-		Object[] listValues2 = listValues2();
-		for (Object object : listValues2) {
-			Object[] array = (Object[]) object;
-			check_get((Integer)array[0], (Integer) array[1], (VirtualList<Integer>) array[2]);
-		}
-		
-	}
-	
-	private Object[] listValues2()
-	{
-		return $( 
-				 virtualist( 100 , 15 , 10  ,  20 ,  10  ) ,
-				 virtualist( 100 , 15 , 85  ,  99 ,  14  ) 
-			);
-	}
+    private VirtualList<Integer> underTest;
 
-	private Object[] virtualist(int realSize , int subListSize , int subListOffset , Integer index, Integer expectedValue) {
+    @Test
+    public void test_virtual_list() {
+        List<Integer> integers = Lists.newArrayList(3, 4, 5);
 
-		return new Object [] { 
-				index , expectedValue , new VirtualList<Integer>(subList(subListSize), subListOffset, realSize) }				
-				;
-	}
+        VirtualList<Integer> underTest = new VirtualList<Integer>(integers, 3, 10);
+        Assertions.assertThat(underTest.subList(3, 6)).hasSize(3);
+        Assertions.assertThat(underTest.get(3)).isEqualTo(3);
+    }
 
-	private List<Integer> subList(int subListSize) {
-		List<Integer> lit = new LinkedList<Integer>();
-		
-		for(int i = 0 ; i < subListSize ; i ++)
-		{
-			lit.add(i);
-		}
-		
-		return lit;
-	}
-	
-	@Test
-	public void check_sublist ()
-	{
-		// list from 0 to 29
-		List<Integer> subList = subList(30);
-		
-		// virtual list from 0 to 100 with sublist from 50 to 80 
-		VirtualList<Integer> virtualList = new VirtualList<Integer>(subList, 50, 100);
-		
-		List<Integer> subList2 = virtualList.subList(50, 65);
-		Assertions.assertThat(subList2).contains(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14);
-		
-	}
-	
+    @Test
+    public void test_virtual_list_edge_cases() {
+        List<Integer> integers = Lists.newArrayList(0);
+
+        VirtualList<Integer> underTest = new VirtualList<Integer>(integers, 0, 1);
+        Assertions.assertThat(underTest.subList(0, 1)).hasSize(1);
+        Assertions.assertThat(underTest.get(0)).isEqualTo(0);
+    }
+
+//    @Test
+//    public void getTests() {
+//        Object[] listValues2 = listValues2();
+//        for (Object object : listValues2) {
+//            Object[] array = (Object[]) object;
+//            check_get((Integer) array[0], (Integer) array[1], (VirtualList<Integer>) array[2]);
+//        }
+//    }
+
+    private Object[] listValues2() {
+        return $(
+                virtualist(100, 15, 10, 20, 10),
+                virtualist(100, 15, 85, 99, 14)
+        );
+    }
+
+    private Object[] virtualist(int realSize, int subListSize, int subListOffset, Integer index, Integer expectedValue) {
+
+        return new Object[]{index, expectedValue, new VirtualList<Integer>(subList(subListSize), subListOffset, realSize)};
+    }
+
+    private List<Integer> subList(int subListSize) {
+        List<Integer> lit = new LinkedList<Integer>();
+
+        for (int i = 0; i < subListSize; i++) {
+            lit.add(i);
+        }
+
+        return lit;
+    }
+
+    @Test
+    public void check_sublist() {
+        // list from 0 to 29
+        List<Integer> subList = subList(30);
+
+        // virtual list from 0 to 100 with sublist from 50 to 80
+        VirtualList<Integer> virtualList = new VirtualList<Integer>(subList, 50, 100);
+
+        List<Integer> subList2 = virtualList.subList(50, 65);
+        Assertions.assertThat(subList2).contains(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14);
+    }
+
 
 }


### PR DESCRIPTION
When the data of a request sub list haven't been loaded, the virtual list fails explicitly instead of returning an empty list.

Add more tests on the view API.
