### PR TITLE
Create a DomainRegistry to access to domain objects (repository,factory, service, policy)

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -48,6 +48,12 @@
             <version>0.7.3</version>
         </dependency>
 
+		<dependency>
+			<groupId>org.jmockit</groupId>
+			<artifactId>jmockit</artifactId>
+			<version>1.19</version>
+			<scope>test</scope>
+		</dependency>
         <dependency>
             <groupId>org.easytesting</groupId>
             <artifactId>fest-reflect</artifactId>

--- a/core/src/it/java/org/seedstack/business/internal/registry/DomainRegistyIT.java
+++ b/core/src/it/java/org/seedstack/business/internal/registry/DomainRegistyIT.java
@@ -1,0 +1,162 @@
+/**
+ * Copyright (c) 2013-2015 by The SeedStack authors. All rights reserved.
+ *
+ * This file is part of SeedStack, An enterprise-oriented full development stack.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.seedstack.business.internal.registry;
+
+import javax.inject.Inject;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.seedstack.business.api.Service;
+import org.seedstack.business.api.domain.DomainPolicy;
+import org.seedstack.business.api.domain.DomainRegistry;
+import org.seedstack.business.api.domain.Factory;
+import org.seedstack.business.api.domain.Repository;
+import org.seedstack.business.internal.registry.fixtures.domain.Client;
+import org.seedstack.business.internal.registry.fixtures.domain.Composite;
+import org.seedstack.business.internal.registry.fixtures.domain.Product;
+import org.seedstack.business.internal.registry.fixtures.policy.PolicyQualifier;
+import org.seedstack.business.internal.registry.fixtures.policy.RebatePolicy;
+import org.seedstack.business.internal.registry.fixtures.policy.RebatePolicyInternalWithQualifier;
+import org.seedstack.business.internal.registry.fixtures.service.MyService;
+import org.seedstack.business.internal.registry.fixtures.service.MyServiceInternal;
+import org.seedstack.business.internal.registry.fixtures.service.MyServiceInternalWithQualiferNamed;
+import org.seedstack.business.internal.registry.fixtures.service.RebateService;
+import org.seedstack.business.internal.registry.fixtures.service.RebateServiceInternal;
+import org.seedstack.business.internal.registry.fixtures.service.RebateServiceInternalWithQualifierComposite;
+import org.seedstack.business.internal.registry.fixtures.service.RebateServiceInternalWithQualifierNamed;
+import org.seedstack.business.internal.registry.fixtures.service.ServiceQualifier;
+import org.seedstack.business.internal.registry.repository.ClientRepository;
+import org.seedstack.business.internal.registry.repository.JpaQualifier;
+import org.seedstack.seed.core.api.TypeOf;
+import org.seedstack.seed.it.SeedITRunner;
+
+
+/**
+ * Integration test for {@link DomainRegistry}.
+ * @author thierry.bouvet@mpsa.com
+ *
+ */
+@RunWith(SeedITRunner.class)
+public class DomainRegistyIT {
+
+	@Inject
+	DomainRegistry domainRegistry;
+	
+	/**
+	 * Test to get a {@link Service} from the {@link DomainRegistry}.
+	 */
+	@Test
+	public void testServiceBase() {
+		MyService service = this.domainRegistry.getService(MyService.class);
+		Assertions.assertThat(service).isInstanceOf(MyServiceInternal.class);
+	}
+	
+	/**
+	 * Test to get a {@link Service} from the {@link DomainRegistry}.
+	 */
+	@Test
+	public void testService() {
+		TypeOf<RebateService<Client>> type = new TypeOf<RebateService<Client>>(){};
+
+		RebateService<Client> service = this.domainRegistry.getService(type);
+		Assertions.assertThat(service).isInstanceOf(RebateServiceInternal.class);
+	}
+
+	/**
+	 * Test to get a {@link Service} from the {@link DomainRegistry}.
+	 */
+	@Test
+	public void testServiceWithStringQualifierFromTypeOf() {
+		TypeOf<RebateService<Client>> type = new TypeOf<RebateService<Client>>(){};
+
+		RebateService<Client> service = this.domainRegistry.getService(type,"Dummy");
+		Assertions.assertThat(service).isInstanceOf(RebateServiceInternalWithQualifierNamed.class);
+	}
+
+	/**
+	 * Test to get a {@link Service} from the {@link DomainRegistry}.
+	 */
+	@Test
+	public void testServiceWithStringQualifier() {
+		MyService service = this.domainRegistry.getService(MyService.class,"Dummy");
+		Assertions.assertThat(service).isInstanceOf(MyServiceInternalWithQualiferNamed.class);
+	}
+
+	/**
+	 * Test to get a {@link Service} with a qualifier from the {@link DomainRegistry}.
+	 */
+	@Test
+	public void testServiceWithQualifierAndComposite() {
+		TypeOf<RebateService<Composite<Long>>> type = new TypeOf<RebateService<Composite<Long>>>(){};
+		RebateService<Composite<Long>> service = this.domainRegistry.getService(type,ServiceQualifier.class);
+		Assertions.assertThat(service).isInstanceOf(RebateServiceInternalWithQualifierComposite.class);
+
+	}
+
+	/**
+	 * Test to get a {@link DomainPolicy} from the {@link DomainRegistry}.
+	 */
+	@Test
+	public void testPolicy() {
+		RebatePolicy policy = this.domainRegistry.getPolicy(RebatePolicy.class);
+		final int rebateExpected = 10;
+		Assertions.assertThat(policy.calculateRebate(new Product(),10000)).isEqualTo(rebateExpected);
+	}
+
+	/**
+	 * Test to get a {@link DomainPolicy} with a qualifier from the {@link DomainRegistry}.
+	 */
+	@Test
+	public void testPolicyWithQualifier() {
+		RebatePolicy policy = this.domainRegistry.getPolicy(RebatePolicy.class,PolicyQualifier.class);
+		Assertions.assertThat(policy).isInstanceOf(RebatePolicyInternalWithQualifier.class);
+	}
+
+	/**
+	 * Test to get a {@link Repository} from the {@link DomainRegistry}.
+	 */
+	@Test
+	public void testRepository() {
+		Repository<Client, Long> repository = this.domainRegistry.getRepository(Client.class, Long.class, JpaQualifier.class);
+		Assertions.assertThat(repository).isInstanceOf(ClientRepository.class);
+	}
+
+	/**
+	 * Test to get a {@link Repository} from the {@link DomainRegistry}.
+	 */
+	@Test
+	public void testRepositoryFromTypeOf() {
+		TypeOf<Repository<Client, Long>> typeOf = new TypeOf<Repository<Client, Long>>(){};
+		Repository<Client, Long> repository = this.domainRegistry.getRepository(typeOf, JpaQualifier.class);
+		Assertions.assertThat(repository).isInstanceOf(ClientRepository.class);
+	}
+
+	/**
+	 * Test to get a {@link Factory} from the {@link DomainRegistry}.
+	 */
+	@Test
+	public void testFactory() {
+		Factory<Client> factory = domainRegistry.getFactory(Client.class);
+		Assertions.assertThat(factory).isInstanceOf(Factory.class);
+	}
+
+	/**
+	 * Test to get a {@link Factory} from the {@link DomainRegistry}.
+	 */
+	@Test
+	public void testFactoryFromTypeOf() {
+		TypeOf<Factory<Client>> typeOf = new TypeOf<Factory<Client>>(){};
+
+		Factory<Client> factory = domainRegistry.getFactory(typeOf);
+		Assertions.assertThat(factory).isInstanceOf(Factory.class);
+	}
+
+}

--- a/core/src/it/java/org/seedstack/business/internal/registry/fixtures/domain/Client.java
+++ b/core/src/it/java/org/seedstack/business/internal/registry/fixtures/domain/Client.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2013-2015 by The SeedStack authors. All rights reserved.
+ *
+ * This file is part of SeedStack, An enterprise-oriented full development stack.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.seedstack.business.internal.registry.fixtures.domain;
+
+import org.seedstack.business.api.domain.BaseAggregateRoot;
+
+/**
+ * Dummy class.
+ * @author thierry.bouvet@mpsa.com
+ *
+ */
+public class Client extends BaseAggregateRoot<Long>{
+
+    @Override
+    public Long getEntityId() {
+        return 1L;
+    }
+
+}

--- a/core/src/it/java/org/seedstack/business/internal/registry/fixtures/domain/Composite.java
+++ b/core/src/it/java/org/seedstack/business/internal/registry/fixtures/domain/Composite.java
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) 2013-2015 by The SeedStack authors. All rights reserved.
+ *
+ * This file is part of SeedStack, An enterprise-oriented full development stack.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.seedstack.business.internal.registry.fixtures.domain;
+
+/**
+ * Dummy class.
+ * @author thierry.bouvet@mpsa.com
+ *
+ */public class Composite<T> {
+
+}

--- a/core/src/it/java/org/seedstack/business/internal/registry/fixtures/domain/Product.java
+++ b/core/src/it/java/org/seedstack/business/internal/registry/fixtures/domain/Product.java
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) 2013-2015 by The SeedStack authors. All rights reserved.
+ *
+ * This file is part of SeedStack, An enterprise-oriented full development stack.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.seedstack.business.internal.registry.fixtures.domain;
+
+/**
+ * Dummy class.
+ * @author thierry.bouvet@mpsa.com
+ *
+ */public class Product {
+
+}

--- a/core/src/it/java/org/seedstack/business/internal/registry/fixtures/policy/PolicyQualifier.java
+++ b/core/src/it/java/org/seedstack/business/internal/registry/fixtures/policy/PolicyQualifier.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2013-2015 by The SeedStack authors. All rights reserved.
+ *
+ * This file is part of SeedStack, An enterprise-oriented full development stack.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.seedstack.business.internal.registry.fixtures.policy;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import javax.inject.Qualifier;
+
+/**
+ * Dummy class.
+ * @author thierry.bouvet@mpsa.com
+ *
+ */@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Qualifier
+public @interface PolicyQualifier {
+}

--- a/core/src/it/java/org/seedstack/business/internal/registry/fixtures/policy/RebatePolicy.java
+++ b/core/src/it/java/org/seedstack/business/internal/registry/fixtures/policy/RebatePolicy.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2013-2015 by The SeedStack authors. All rights reserved.
+ *
+ * This file is part of SeedStack, An enterprise-oriented full development stack.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.seedstack.business.internal.registry.fixtures.policy;
+
+import org.seedstack.business.api.domain.DomainPolicy;
+import org.seedstack.business.internal.registry.fixtures.domain.Product;
+
+/**
+ * Dummy class.
+ * @author thierry.bouvet@mpsa.com
+ *
+ */
+@DomainPolicy
+public interface RebatePolicy {
+
+	public float calculateRebate(Product product, float quantity);
+}

--- a/core/src/it/java/org/seedstack/business/internal/registry/fixtures/policy/RebatePolicyInternal.java
+++ b/core/src/it/java/org/seedstack/business/internal/registry/fixtures/policy/RebatePolicyInternal.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2013-2015 by The SeedStack authors. All rights reserved.
+ *
+ * This file is part of SeedStack, An enterprise-oriented full development stack.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.seedstack.business.internal.registry.fixtures.policy;
+
+import org.seedstack.business.internal.registry.fixtures.domain.Product;
+
+/**
+ * Dummy class.
+ * @author thierry.bouvet@mpsa.com
+ *
+ */
+public class RebatePolicyInternal implements RebatePolicy{
+
+	@Override
+	public float calculateRebate(Product product, float quantity) {
+		return quantity / 1000;
+	}
+
+}

--- a/core/src/it/java/org/seedstack/business/internal/registry/fixtures/policy/RebatePolicyInternalWithQualifier.java
+++ b/core/src/it/java/org/seedstack/business/internal/registry/fixtures/policy/RebatePolicyInternalWithQualifier.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2013-2015 by The SeedStack authors. All rights reserved.
+ *
+ * This file is part of SeedStack, An enterprise-oriented full development stack.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.seedstack.business.internal.registry.fixtures.policy;
+
+import org.seedstack.business.internal.registry.fixtures.domain.Product;
+
+/**
+ * Dummy class.
+ * @author thierry.bouvet@mpsa.com
+ *
+ */
+@PolicyQualifier
+public class RebatePolicyInternalWithQualifier implements RebatePolicy{
+
+	@Override
+	public float calculateRebate(Product product, float quantity) {
+		return quantity / 10;
+	}
+
+}

--- a/core/src/it/java/org/seedstack/business/internal/registry/fixtures/service/MyService.java
+++ b/core/src/it/java/org/seedstack/business/internal/registry/fixtures/service/MyService.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2013-2015 by The SeedStack authors. All rights reserved.
+ *
+ * This file is part of SeedStack, An enterprise-oriented full development stack.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.seedstack.business.internal.registry.fixtures.service;
+
+import org.seedstack.business.api.Service;
+
+/**
+ * Dummy class.
+ * @author thierry.bouvet@mpsa.com
+ *
+ */
+@Service
+public interface MyService {
+}

--- a/core/src/it/java/org/seedstack/business/internal/registry/fixtures/service/MyServiceInternal.java
+++ b/core/src/it/java/org/seedstack/business/internal/registry/fixtures/service/MyServiceInternal.java
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) 2013-2015 by The SeedStack authors. All rights reserved.
+ *
+ * This file is part of SeedStack, An enterprise-oriented full development stack.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.seedstack.business.internal.registry.fixtures.service;
+
+/**
+ * Dummy class.
+ * @author thierry.bouvet@mpsa.com
+ *
+ */
+public class MyServiceInternal implements MyService {
+
+}

--- a/core/src/it/java/org/seedstack/business/internal/registry/fixtures/service/MyServiceInternalWithQualiferNamed.java
+++ b/core/src/it/java/org/seedstack/business/internal/registry/fixtures/service/MyServiceInternalWithQualiferNamed.java
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2013-2015 by The SeedStack authors. All rights reserved.
+ *
+ * This file is part of SeedStack, An enterprise-oriented full development stack.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.seedstack.business.internal.registry.fixtures.service;
+
+import javax.inject.Named;
+
+/**
+ * Dummy class.
+ * @author thierry.bouvet@mpsa.com
+ *
+ */
+@Named("Dummy")
+public class MyServiceInternalWithQualiferNamed implements MyService {
+
+}

--- a/core/src/it/java/org/seedstack/business/internal/registry/fixtures/service/RebateService.java
+++ b/core/src/it/java/org/seedstack/business/internal/registry/fixtures/service/RebateService.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2013-2015 by The SeedStack authors. All rights reserved.
+ *
+ * This file is part of SeedStack, An enterprise-oriented full development stack.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.seedstack.business.internal.registry.fixtures.service;
+
+import org.seedstack.business.api.Service;
+
+/**
+ * Dummy class.
+ * @author thierry.bouvet@mpsa.com
+ *
+ */
+@Service
+public interface RebateService<T> {
+}

--- a/core/src/it/java/org/seedstack/business/internal/registry/fixtures/service/RebateServiceInternal.java
+++ b/core/src/it/java/org/seedstack/business/internal/registry/fixtures/service/RebateServiceInternal.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2013-2015 by The SeedStack authors. All rights reserved.
+ *
+ * This file is part of SeedStack, An enterprise-oriented full development stack.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.seedstack.business.internal.registry.fixtures.service;
+
+import org.seedstack.business.internal.registry.fixtures.domain.Client;
+
+/**
+ * Dummy class.
+ * @author thierry.bouvet@mpsa.com
+ *
+ */
+public class RebateServiceInternal implements RebateService<Client>{
+
+}

--- a/core/src/it/java/org/seedstack/business/internal/registry/fixtures/service/RebateServiceInternalWithQualifier.java
+++ b/core/src/it/java/org/seedstack/business/internal/registry/fixtures/service/RebateServiceInternalWithQualifier.java
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2013-2015 by The SeedStack authors. All rights reserved.
+ *
+ * This file is part of SeedStack, An enterprise-oriented full development stack.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.seedstack.business.internal.registry.fixtures.service;
+
+import org.seedstack.business.internal.registry.fixtures.domain.Client;
+
+/**
+ * Dummy class.
+ * @author thierry.bouvet@mpsa.com
+ *
+ */
+@ServiceQualifier
+public class RebateServiceInternalWithQualifier implements RebateService<Client>{
+
+}

--- a/core/src/it/java/org/seedstack/business/internal/registry/fixtures/service/RebateServiceInternalWithQualifierComposite.java
+++ b/core/src/it/java/org/seedstack/business/internal/registry/fixtures/service/RebateServiceInternalWithQualifierComposite.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2013-2015 by The SeedStack authors. All rights reserved.
+ *
+ * This file is part of SeedStack, An enterprise-oriented full development stack.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.seedstack.business.internal.registry.fixtures.service;
+
+import org.seedstack.business.internal.registry.fixtures.domain.Composite;
+
+/**
+ * Dummy class.
+ * @author thierry.bouvet@mpsa.com
+ *
+ */
+@ServiceQualifier
+public class RebateServiceInternalWithQualifierComposite implements RebateService<Composite<Long>>{
+}

--- a/core/src/it/java/org/seedstack/business/internal/registry/fixtures/service/RebateServiceInternalWithQualifierNamed.java
+++ b/core/src/it/java/org/seedstack/business/internal/registry/fixtures/service/RebateServiceInternalWithQualifierNamed.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2013-2015 by The SeedStack authors. All rights reserved.
+ *
+ * This file is part of SeedStack, An enterprise-oriented full development stack.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.seedstack.business.internal.registry.fixtures.service;
+
+
+import javax.inject.Named;
+
+import org.seedstack.business.internal.registry.fixtures.domain.Client;
+
+/**
+ * Dummy class.
+ * @author thierry.bouvet@mpsa.com
+ *
+ */
+@Named("Dummy")
+public class RebateServiceInternalWithQualifierNamed implements RebateService<Client>{
+
+}

--- a/core/src/it/java/org/seedstack/business/internal/registry/fixtures/service/ServiceQualifier.java
+++ b/core/src/it/java/org/seedstack/business/internal/registry/fixtures/service/ServiceQualifier.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2013-2015 by The SeedStack authors. All rights reserved.
+ *
+ * This file is part of SeedStack, An enterprise-oriented full development stack.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.seedstack.business.internal.registry.fixtures.service;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import javax.inject.Qualifier;
+
+/**
+ * Dummy class.
+ * @author thierry.bouvet@mpsa.com
+ *
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Qualifier
+public @interface ServiceQualifier {
+}

--- a/core/src/it/java/org/seedstack/business/internal/registry/repository/ClientRepository.java
+++ b/core/src/it/java/org/seedstack/business/internal/registry/repository/ClientRepository.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2013-2015 by The SeedStack authors. All rights reserved.
+ *
+ * This file is part of SeedStack, An enterprise-oriented full development stack.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.seedstack.business.internal.registry.repository;
+
+import org.seedstack.business.api.domain.AggregateRoot;
+import org.seedstack.business.api.domain.BaseRepository;
+import org.seedstack.business.spi.GenericImplementation;
+
+/**
+ * Dummy class.
+ * @author thierry.bouvet@mpsa.com
+ *
+ */
+@GenericImplementation
+@JpaQualifier
+public class ClientRepository<A extends AggregateRoot<K>, K> extends BaseRepository<A, K>{
+
+	@Override
+	protected A doLoad(K id) {
+		return null;
+	}
+
+	@Override
+	protected void doDelete(K id) {
+	}
+
+	@Override
+	protected void doDelete(A aggregate) {
+	}
+
+	@Override
+	protected void doPersist(A aggregate) {
+	}
+
+	@Override
+	protected A doSave(A aggregate) {
+		return null;
+	}
+
+}

--- a/core/src/it/java/org/seedstack/business/internal/registry/repository/JpaQualifier.java
+++ b/core/src/it/java/org/seedstack/business/internal/registry/repository/JpaQualifier.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2013-2015 by The SeedStack authors. All rights reserved.
+ *
+ * This file is part of SeedStack, An enterprise-oriented full development stack.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.seedstack.business.internal.registry.repository;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import javax.inject.Qualifier;
+
+/**
+ * Dummy class.
+ * @author thierry.bouvet@mpsa.com
+ *
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Qualifier
+public @interface JpaQualifier {
+}

--- a/core/src/main/java/org/seedstack/business/internal/BusinessModule.java
+++ b/core/src/main/java/org/seedstack/business/internal/BusinessModule.java
@@ -11,10 +11,13 @@ package org.seedstack.business.internal;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.Key;
+
+import org.seedstack.business.api.domain.DomainRegistry;
 import org.seedstack.business.api.interfaces.assembler.FluentAssembler;
 import org.seedstack.business.internal.assembler.dsl.FluentAssemblerImpl;
 import org.seedstack.business.internal.assembler.dsl.InternalRegistry;
 import org.seedstack.business.internal.assembler.dsl.InternalRegistryInternal;
+import org.seedstack.business.internal.registry.DomainRegistryImpl;
 import org.seedstack.business.internal.strategy.api.BindingStrategy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -59,13 +62,13 @@ class BusinessModule extends AbstractModule {
 		this.bindingStrategies = bindingStrategies;
 	}
 
-	@SuppressWarnings("deprecation")
 	@Override
 	protected void configure() {
         bind(FluentAssembler.class).to(FluentAssemblerImpl.class);
         bind(InternalRegistry.class).to(InternalRegistryInternal.class);
+        bind(DomainRegistry.class).to(DomainRegistryImpl.class);
 
-		for (Entry<Key<?>, Class<?>> binding : bindings.entrySet()) {
+        for (Entry<Key<?>, Class<?>> binding : bindings.entrySet()) {
 			logger.trace("Binding {} to {}.", binding.getKey(), binding.getValue().getSimpleName());
 			bind(binding.getKey()).to((Class) binding.getValue());
 		}

--- a/core/src/main/java/org/seedstack/business/internal/registry/DomainRegistryImpl.java
+++ b/core/src/main/java/org/seedstack/business/internal/registry/DomainRegistryImpl.java
@@ -1,0 +1,210 @@
+/**
+ * Copyright (c) 2013-2015 by The SeedStack authors. All rights reserved.
+ *
+ * This file is part of SeedStack, An enterprise-oriented full development stack.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.seedstack.business.internal.registry;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+
+import javax.inject.Inject;
+import javax.inject.Qualifier;
+
+import org.seedstack.business.api.Producible;
+import org.seedstack.business.api.domain.AggregateRoot;
+import org.seedstack.business.api.domain.DomainObject;
+import org.seedstack.business.api.domain.DomainRegistry;
+import org.seedstack.business.api.domain.Factory;
+import org.seedstack.business.api.domain.Repository;
+import org.seedstack.seed.core.api.TypeOf;
+
+import com.google.inject.Injector;
+import com.google.inject.Key;
+import com.google.inject.name.Names;
+import com.google.inject.util.Types;
+
+/**
+ * Registry to access to all domain objects (repository, factory, service, policy).
+ * 
+ * @author thierry.bouvet@mpsa.com
+ *
+ */
+public class DomainRegistryImpl implements DomainRegistry {
+
+	@Inject
+	private Injector injector;
+
+	@Override
+	public <T extends Repository<A, K>, A extends AggregateRoot<K>, K> T getRepository(TypeOf<T> typeOf,
+			Class<? extends Annotation> qualifier) {
+		return getInstance(getKey(typeOf.getType(), qualifier));
+	}
+
+	@Override
+	public <T extends Repository<A, K>, A extends AggregateRoot<K>, K> T getRepository(TypeOf<T> typeOf,
+			String qualifier) {
+		return getInstance(getKey(typeOf.getType(), qualifier));
+	}
+
+	@Override
+	public <A extends AggregateRoot<K>, K> Repository<A, K> getRepository(Class<A> aggregateRoot, Class<K> key,
+			Class<? extends Annotation> qualifier) {
+		return getInstance(getKey(getType(Repository.class,aggregateRoot, key),qualifier));
+	}
+
+	@Override
+	public <A extends AggregateRoot<K>, K> Repository<A, K> getRepository(Class<A> aggregateRoot, Class<K> key,
+			String qualifier) {
+		return getInstance(getKey(getType(Repository.class,aggregateRoot, key),qualifier));
+	}
+
+	@Override
+	public <T extends Factory<A>,A extends DomainObject & Producible> T getFactory(TypeOf<T> typeOf) {
+		return getInstance(getKey(typeOf.getType()));
+	}
+
+	@Override
+	public <T extends Factory<A>,A extends DomainObject & Producible> T getFactory(TypeOf<T> typeOf,
+			Class<? extends Annotation> qualifier) {
+		return getInstance(getKey(typeOf.getType(), qualifier));
+	}
+
+	@Override
+	public <T extends Factory<A>, A extends DomainObject & Producible> T getFactory(TypeOf<T> typeOf, String qualifier) {
+		return getInstance(getKey(typeOf.getType(), qualifier));
+	}
+
+	@Override
+	public <T extends DomainObject & Producible> Factory<T> getFactory(Class<T> aggregateRoot) {
+		return getInstance(getKey(getType(Factory.class, aggregateRoot)));
+	}
+
+	@Override
+	public <T extends DomainObject & Producible> Factory<T> getFactory(Class<T> aggregateRoot,
+			Class<? extends Annotation> qualifier) {
+		return getInstance(getKey(getType(Factory.class, aggregateRoot), qualifier));
+	}
+
+	@Override
+	public <T extends DomainObject & Producible> Factory<T> getFactory(Class<T> aggregateRoot, String qualifier) {
+		return getInstance(getKey(getType(Factory.class, aggregateRoot), qualifier));
+	}
+
+	@Override
+	public <T> T getService(TypeOf<T> typeOf) {
+		return getInstance(getKey(typeOf.getType()));
+	}
+
+	@Override
+	public <T> T getService(TypeOf<T> typeOf, Class<? extends Annotation> qualifier) {
+		return getInstance(getKey(typeOf.getType(), qualifier));
+	}
+
+	@Override
+	public <T> T getService(TypeOf<T> typeOf, String qualifier) {
+		return getInstance(getKey(typeOf.getType(), qualifier));
+	}
+
+	@Override
+	public <T> T getService(Class<T> rawType) {
+		return getInstance(getKey(getType(rawType)));
+	}
+
+	@Override
+	public <T> T getService(Class<T> rawType, Class<? extends Annotation> qualifier) {
+		return getInstance(getKey(rawType,qualifier));
+	}
+
+
+	@Override
+	public <T> T getService(Class<T> rawType, String qualifier) {
+		return getInstance(getKey(getType(rawType),qualifier));
+	}
+
+	@Override
+	public <T> T getPolicy(Class<T> rawType) {
+		return getInstance(getKey(getType(rawType)));
+	}
+
+	@Override
+	public <T> T getPolicy(Class<T> rawType, Class<? extends Annotation> qualifier) {
+		return getInstance(getKey(rawType,qualifier));
+	}
+
+	@Override
+	public <T> T getPolicy(Class<T> rawType, String qualifier) {
+		return getInstance(getKey(getType(rawType),qualifier));
+	}
+
+	@Override
+	public <T> T getPolicy(TypeOf<T> typeOf) {
+		return getInstance(getKey(typeOf.getType()));
+	}
+
+	@Override
+	public <T> T getPolicy(TypeOf<T> typeOf, Class<? extends Annotation> qualifier) {
+		return getInstance(getKey(typeOf.getType(), qualifier));
+	}
+
+	@Override
+	public <T> T getPolicy(TypeOf<T> typeOf, String qualifier) {
+		return getInstance(getKey(typeOf.getType(), qualifier));
+	}
+
+	/**
+	 * Get an instance for a defined {@link Key}.
+	 * @param key key to find in {@link Injector}
+	 * @return an instance bound to the {@link Key}.
+	 */
+	@SuppressWarnings("unchecked")
+	private <T> T getInstance(Key<?> key) {
+		return (T) injector.getInstance(key);
+	}
+
+	/**
+	 * Get a {@link Key} for a defined class and a qualifier.
+	 * @param rawType class 
+	 * @param qualifier Optional Key {@link Qualifier}.
+	 * @return the {@link Key}.
+	 */
+	private <T> Key<?> getKey(Type type, Class<? extends Annotation> qualifier) {
+		return Key.get(type,qualifier);
+	}
+
+	/**
+	 * Get a {@link Key} for a defined class and a qualifier.
+	 * @param rawType class 
+	 * @return the {@link Key}.
+	 */
+	private <T> Key<?> getKey(Type type, String qualifier) {
+		return Key.get(type, Names.named(qualifier));
+	}
+
+	/**
+	 * Get a {@link Key} for a defined class and a qualifier.
+	 * @param rawType class 
+	 * @param qualifier Optional Key {@link Qualifier}.
+	 * @return the {@link Key}.
+	 */
+	private <T> Key<?> getKey(Type type) {
+		return Key.get(type);
+	}
+
+	/**
+	 * Get a {@link Type} for a defined class.
+	 * @param rawType class 
+	 * @param typeArguments parameterized types
+	 * @return the {@link Type}
+	 */
+	private Type getType(Type rawType, Type... typeArguments) {
+		if (typeArguments.length == 0) {
+			return rawType;
+		}
+		return Types.newParameterizedType(rawType, typeArguments);
+	}
+}

--- a/core/src/test/java/org/seedstack/business/internal/registry/DomainRegistryImplTest.java
+++ b/core/src/test/java/org/seedstack/business/internal/registry/DomainRegistryImplTest.java
@@ -1,0 +1,407 @@
+/**
+ * Copyright (c) 2013-2015 by The SeedStack authors. All rights reserved.
+ *
+ * This file is part of SeedStack, An enterprise-oriented full development stack.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.seedstack.business.internal.registry;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+import org.seedstack.business.api.domain.AggregateRoot;
+import org.seedstack.business.api.domain.DomainElement;
+import org.seedstack.business.api.domain.DomainRegistry;
+import org.seedstack.business.api.domain.Factory;
+import org.seedstack.business.api.domain.Repository;
+import org.seedstack.seed.core.api.TypeOf;
+
+import com.google.inject.BindingAnnotation;
+import com.google.inject.Injector;
+import com.google.inject.Key;
+
+import mockit.Deencapsulation;
+import mockit.Mocked;
+import mockit.StrictExpectations;
+
+/**
+ * Unit test for {@link DomainRegistryImpl}
+ * @author thierry.bouvet@mpsa.com
+ *
+ */
+public class DomainRegistryImplTest {
+
+	@Mocked private Injector injector;
+
+	@DomainElement
+	@Retention(RetentionPolicy.RUNTIME)
+	@Target({ ElementType.TYPE})
+	@BindingAnnotation
+	private @interface MockedAnnotation {
+	}
+
+	private interface MockedService {};
+	
+	private interface MockedServiceParameterized<T> {};
+
+	private interface MockedPolicy {};
+
+	private interface MockedPolicyParameterized<T> {};
+
+
+	/**
+	 * Create a {@link DomainRegistry} with a mocker {@link Injector}.
+	 * @return a new {@link DomainRegistry}
+	 */
+	private DomainRegistry createDomainRegistry() {
+		DomainRegistry domainRegistry = new DomainRegistryImpl();
+		Deencapsulation.setField(domainRegistry, "injector", injector);
+		return domainRegistry;
+	}
+
+	@SuppressWarnings({ "unchecked" })
+	@Test
+	public void testGetRepositoryTypeOfOfTClassOfQextendsAnnotation(final @Mocked Repository<AggregateRoot<Long>, Long> repository) {
+		DomainRegistry domainRegistry = createDomainRegistry();
+		
+		new StrictExpectations() {
+			{
+				injector.getInstance((Key<Repository<AggregateRoot<Long>, Long>>)any);
+				result=repository;
+			}
+		};
+
+		Assertions.assertThat(domainRegistry.getRepository(new TypeOf<Repository<AggregateRoot<Long>, Long>>() {
+		}, MockedAnnotation.class)).isEqualTo(repository);
+	}
+
+	@SuppressWarnings({ "unchecked" })
+	@Test
+	public void testGetRepositoryTypeOfOfTString(final @Mocked Repository<AggregateRoot<Long>, Long> repository) {
+		DomainRegistry domainRegistry = createDomainRegistry();
+		
+		new StrictExpectations() {
+			{
+				injector.getInstance((Key<Repository<AggregateRoot<Long>, Long>>)any);
+				result=repository;
+			}
+		};
+
+		Assertions.assertThat(domainRegistry.getRepository(new TypeOf<Repository<AggregateRoot<Long>, Long>>() {
+		}, "dummyAnnotation")).isEqualTo(repository);
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	public void testGetRepositoryClassOfAClassOfKClassOfQextendsAnnotation(final @Mocked Repository<AggregateRoot<Long>, Long> repository) {
+		DomainRegistry domainRegistry = createDomainRegistry();
+		
+		new StrictExpectations() {
+			{
+				injector.getInstance((Key<Repository<AggregateRoot<Long>, Long>>)any);
+				result=repository;
+			}
+		};
+
+		Assertions.assertThat(domainRegistry.getRepository(AggregateRoot.class, Long.class,MockedAnnotation.class)).isEqualTo(repository);
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	public void testGetRepositoryClassOfAClassOfKString(final @Mocked Repository<AggregateRoot<Long>, Long> repository) {
+		DomainRegistry domainRegistry = createDomainRegistry();
+		
+		new StrictExpectations() {
+			{
+				injector.getInstance((Key<Repository<AggregateRoot<Long>, Long>>)any);
+				result=repository;
+			}
+		};
+
+		Assertions.assertThat(domainRegistry.getRepository(AggregateRoot.class, Long.class,"dummyAnnotation")).isEqualTo(repository);
+	}
+
+	@SuppressWarnings({ "unchecked" })
+	@Test
+	public void testGetFactoryTypeOfOfT(final @Mocked Factory<?> factory) {
+		DomainRegistry domainRegistry = createDomainRegistry();
+		
+		new StrictExpectations() {
+			{
+				injector.getInstance((Key<Factory<AggregateRoot<Long>>>)any);
+				result=factory;
+			}
+		};
+
+		Assertions.assertThat(domainRegistry.getFactory(new TypeOf<Factory<AggregateRoot<Long>>>() {
+		})).isEqualTo(factory);
+	}
+
+	@SuppressWarnings({ "unchecked" })
+	@Test
+	public void testGetFactoryTypeOfOfTClassOfQextendsAnnotation(final @Mocked Factory<?> factory) {
+		DomainRegistry domainRegistry = createDomainRegistry();
+		
+		new StrictExpectations() {
+			{
+				injector.getInstance((Key<Factory<AggregateRoot<Long>>>)any);
+				result=factory;
+			}
+		};
+
+		Assertions.assertThat(domainRegistry.getFactory(new TypeOf<Factory<AggregateRoot<Long>>>() {
+		}, MockedAnnotation.class)).isEqualTo(factory);
+	}
+
+	@SuppressWarnings({ "unchecked" })
+	@Test
+	public void testGetFactoryTypeOfOfTString(final @Mocked Factory<?> factory) {
+		DomainRegistry domainRegistry = createDomainRegistry();
+		
+		new StrictExpectations() {
+			{
+				injector.getInstance((Key<Factory<AggregateRoot<Long>>>)any);
+				result=factory;
+			}
+		};
+
+		Assertions.assertThat(domainRegistry.getFactory(new TypeOf<Factory<AggregateRoot<Long>>>() {
+		}, "dummyAnnotation")).isEqualTo(factory);
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	public void testGetFactoryClassOfT(final @Mocked Factory<?> factory) {
+		DomainRegistry domainRegistry = createDomainRegistry();
+		
+		new StrictExpectations() {
+			{
+				injector.getInstance((Key<Factory<AggregateRoot<Long>>>)any);
+				result=factory;
+			}
+		};
+
+		Assertions.assertThat(domainRegistry.getFactory(AggregateRoot.class)).isEqualTo(factory);
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	public void testGetFactoryClassOfTClassOfQextendsAnnotation(final @Mocked Factory<?> factory) {
+		DomainRegistry domainRegistry = createDomainRegistry();
+		
+		new StrictExpectations() {
+			{
+				injector.getInstance((Key<Factory<AggregateRoot<Long>>>)any);
+				result=factory;
+			}
+		};
+
+		Assertions.assertThat(domainRegistry.getFactory(AggregateRoot.class,MockedAnnotation.class)).isEqualTo(factory);
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	public void testGetFactoryClassOfTString(final @Mocked Factory<?> factory) {
+		DomainRegistry domainRegistry = createDomainRegistry();
+		
+		new StrictExpectations() {
+			{
+				injector.getInstance((Key<Factory<AggregateRoot<Long>>>)any);
+				result=factory;
+			}
+		};
+
+		Assertions.assertThat(domainRegistry.getFactory(AggregateRoot.class,"dummyAnnotation")).isEqualTo(factory);
+	}
+
+	@SuppressWarnings({ "unchecked" })
+	@Test
+	public void testGetServiceTypeOfOfT(final @Mocked MockedServiceParameterized<Long> service) {
+		DomainRegistry domainRegistry = createDomainRegistry();
+		
+		new StrictExpectations() {
+			{
+				injector.getInstance((Key<MockedServiceParameterized<Long>>)any);
+				result=service;
+			}
+		};
+
+		Assertions.assertThat(domainRegistry.getService(new TypeOf<MockedServiceParameterized<Long>>() {})).isEqualTo(service);
+	}
+
+	@SuppressWarnings({ "unchecked" })
+	@Test
+	public void testGetServiceTypeOfOfTClassOfQextendsAnnotation(final @Mocked MockedServiceParameterized<Long> service) {
+		DomainRegistry domainRegistry = createDomainRegistry();
+		
+		new StrictExpectations() {
+			{
+				injector.getInstance((Key<MockedServiceParameterized<Long>>)any);
+				result=service;
+			}
+		};
+
+		Assertions.assertThat(domainRegistry.getService(new TypeOf<MockedServiceParameterized<Long>>() {},MockedAnnotation.class)).isEqualTo(service);
+	}
+
+	@SuppressWarnings({ "unchecked" })
+	@Test
+	public void testGetServiceTypeOfOfTString(final @Mocked MockedServiceParameterized<Long> service) {
+		DomainRegistry domainRegistry = createDomainRegistry();
+		
+		new StrictExpectations() {
+			{
+				injector.getInstance((Key<MockedServiceParameterized<Long>>)any);
+				result=service;
+			}
+		};
+
+		Assertions.assertThat(domainRegistry.getService(new TypeOf<MockedServiceParameterized<Long>>() {},"dummyAnnotation")).isEqualTo(service);
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	public void testGetServiceClassOfT(final @Mocked MockedService service) {
+		DomainRegistry domainRegistry = createDomainRegistry();
+		
+		new StrictExpectations() {
+			{
+				injector.getInstance((Key<MockedService>)any);
+				result=service;
+			}
+		};
+
+		Assertions.assertThat(domainRegistry.getService(MockedService.class)).isEqualTo(service);
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	public void testGetServiceClassOfTClassOfQextendsAnnotation(final @Mocked MockedService service) {
+		DomainRegistry domainRegistry = createDomainRegistry();
+		
+		new StrictExpectations() {
+			{
+				injector.getInstance((Key<MockedService>)any);
+				result=service;
+			}
+		};
+
+		Assertions.assertThat(domainRegistry.getService(MockedService.class,MockedAnnotation.class)).isEqualTo(service);
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	public void testGetServiceClassOfTString(final @Mocked MockedService service) {
+		DomainRegistry domainRegistry = createDomainRegistry();
+		
+		new StrictExpectations() {
+			{
+				injector.getInstance((Key<MockedService>)any);
+				result=service;
+			}
+		};
+
+		Assertions.assertThat(domainRegistry.getService(MockedService.class,"dummyAnnotation")).isEqualTo(service);
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	public void testGetPolicyClassOfT(final @Mocked MockedPolicy policy) {
+		DomainRegistry domainRegistry = createDomainRegistry();
+		
+		new StrictExpectations() {
+			{
+				injector.getInstance((Key<MockedPolicy>)any);
+				result=policy;
+			}
+		};
+
+		Assertions.assertThat(domainRegistry.getPolicy(MockedPolicy.class)).isEqualTo(policy);
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	public void testGetPolicyClassOfTClassOfQextendsAnnotation(final @Mocked MockedPolicy policy) {
+		DomainRegistry domainRegistry = createDomainRegistry();
+		
+		new StrictExpectations() {
+			{
+				injector.getInstance((Key<MockedPolicy>)any);
+				result=policy;
+			}
+		};
+
+		Assertions.assertThat(domainRegistry.getPolicy(MockedPolicy.class,MockedAnnotation.class)).isEqualTo(policy);
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	public void testGetPolicyClassOfTString(final @Mocked MockedPolicy policy) {
+		DomainRegistry domainRegistry = createDomainRegistry();
+		
+		new StrictExpectations() {
+			{
+				injector.getInstance((Key<MockedPolicy>)any);
+				result=policy;
+			}
+		};
+
+		Assertions.assertThat(domainRegistry.getPolicy(MockedPolicy.class,"dummyAnnotation")).isEqualTo(policy);
+	}
+
+	@SuppressWarnings({ "unchecked" })
+	@Test
+	public void testGetPolicyTypeOfOfT(final @Mocked MockedPolicyParameterized<Long> policy) {
+		DomainRegistry domainRegistry = createDomainRegistry();
+		
+		new StrictExpectations() {
+			{
+				injector.getInstance((Key<MockedPolicyParameterized<Long>>)any);
+				result=policy;
+			}
+		};
+
+		Assertions.assertThat(domainRegistry.getPolicy(new TypeOf<MockedPolicyParameterized<Long>>() {
+		})).isEqualTo(policy);
+	}
+
+	@SuppressWarnings({ "unchecked" })
+	@Test
+	public void testGetPolicyTypeOfOfTClassOfQextendsAnnotation(final @Mocked MockedPolicyParameterized<Long> policy) {
+		DomainRegistry domainRegistry = createDomainRegistry();
+		
+		new StrictExpectations() {
+			{
+				injector.getInstance((Key<MockedPolicyParameterized<Long>>)any);
+				result=policy;
+			}
+		};
+
+		Assertions.assertThat(domainRegistry.getPolicy(new TypeOf<MockedPolicyParameterized<Long>>() {
+		},MockedAnnotation.class)).isEqualTo(policy);
+	}
+
+	@SuppressWarnings({ "unchecked" })
+	@Test
+	public void testGetPolicyTypeOfOfTString(final @Mocked MockedPolicyParameterized<Long> policy) {
+		DomainRegistry domainRegistry = createDomainRegistry();
+		
+		new StrictExpectations() {
+			{
+				injector.getInstance((Key<MockedPolicyParameterized<Long>>)any);
+				result=policy;
+			}
+		};
+
+		Assertions.assertThat(domainRegistry.getPolicy(new TypeOf<MockedPolicyParameterized<Long>>() {
+		},"dummyAnnotation")).isEqualTo(policy);
+	}
+
+}

--- a/specs/src/main/java/org/seedstack/business/api/domain/DomainRegistry.java
+++ b/specs/src/main/java/org/seedstack/business/api/domain/DomainRegistry.java
@@ -1,0 +1,215 @@
+/**
+ * Copyright (c) 2013-2015 by The SeedStack authors. All rights reserved.
+ *
+ * This file is part of SeedStack, An enterprise-oriented full development stack.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.seedstack.business.api.domain;
+
+import java.lang.annotation.Annotation;
+
+import org.seedstack.business.api.Producible;
+import org.seedstack.business.api.Service;
+import org.seedstack.seed.core.api.TypeOf;
+
+/**
+ * Registry to access to all domain objects.
+ * 
+ * <pre>
+ * To use it, just inject it :
+ * 
+ * {@code @Inject}
+ * DomainRegistry domainRegistry
+ * </pre>
+ * 
+ * <pre>
+ * Example for a class without generic parameter:
+ * <code>
+ * 	   MyPolicy policy = domainRegistry.getPolicy(MyPolicy.class,"qualifier");
+ * </code>
+ * 
+ * Example for a class with generic parameter:
+ * <code>
+ * 	   AnotherPolicy&lt;MyClient&lt;Long&gt;&gt; policy = domainRegistry.getPolicy(new TypeOf&lt;AnotherPolicy&lt;MyClient&lt;Long&gt;&gt;&gt;(){},"qualifier");
+ * </code>
+ * </pre>
+ * @author thierry.bouvet@mpsa.com
+ *
+ */
+public interface DomainRegistry {
+
+	/**
+	 * Get a {@link Repository} from the domain.
+	 * @param typeOf the {@link TypeOf} to define all generic pattern.
+	 * @param qualifier repository qualifier
+	 * @return a {@link Repository} found in the domain.
+	 */
+	<T extends Repository<A,K>,A extends AggregateRoot<K>,K> T getRepository(TypeOf<T> typeOf, Class<? extends Annotation> qualifier);
+
+	/**
+	 * Get a {@link Repository} from the domain.
+	 * @param typeOf the {@link TypeOf} to define all generic pattern.
+	 * @param qualifier repository qualifier
+	 * @return a {@link Repository} found in the domain.
+	 */
+	<T extends Repository<A,K>,A extends AggregateRoot<K>,K> T getRepository(TypeOf<T> typeOf, String qualifier);
+
+	/**
+	 * Get the {@link Repository} for an aggregate root and a qualifier.
+	 * @param aggregateRoot the aggregate root linked to the repository.
+	 * @param key the aggregate root's key.
+	 * @param qualifier repository qualifier (example: JPA, ...).
+	 * @return an instance of the {@link Repository}
+	 */
+	<A extends AggregateRoot<K>, K> Repository<A, K> getRepository(Class<A> aggregateRoot, Class<K> key, Class<? extends Annotation> qualifier);
+	
+	/**
+	 * Get the {@link Repository} for an aggregate root and a qualifier.
+	 * @param aggregateRoot the aggregate root linked to the repository.
+	 * @param key the aggregate root's key.
+	 * @param qualifier repository qualifier (example: JPA, ...).
+	 * @return an instance of the {@link Repository}
+	 */
+	<A extends AggregateRoot<K>, K> Repository<A, K> getRepository(Class<A> aggregateRoot, Class<K> key, String qualifier);
+
+	/**
+	 * Get the {@link Factory} for an aggregate root.
+	 * @param aggregateRoot the aggregate root linked to the factoy.
+	 * @return an instance of the {@link Factory}
+	 */
+	<T extends DomainObject & Producible> Factory<T> getFactory(Class<T> aggregateRoot);
+	
+	/**
+	 * Get the {@link Factory} with a qualifier for an aggregate root.
+	 * @param aggregateRoot the aggregate root linked to the factoy.
+	 * @param qualifier factory qualifier.
+	 * @return an instance of the {@link Factory}
+	 */
+	<T extends DomainObject & Producible> Factory<T> getFactory(Class<T> aggregateRoot, Class<? extends Annotation> qualifier);
+
+	/**
+	 * Get the {@link Factory} with a qualifier for an aggregate root.
+	 * @param aggregateRoot the aggregate root linked to the factoy.
+	 * @param qualifier factory qualifier.
+	 * @return an instance of the {@link Factory}
+	 */
+	<T extends DomainObject & Producible> Factory<T> getFactory(Class<T> aggregateRoot, String qualifier);
+
+	/**
+	 * Get a {@link Factory} from the domain.
+	 * @param typeOf the {@link TypeOf} to define all generic pattern.
+	 * @return a {@link Factory} found in the domain.
+	 */
+	<T extends Factory<A>,A extends DomainObject & Producible> T getFactory(TypeOf<T> typeOf);
+
+	/**
+	 * Get a {@link Factory} from the domain.
+	 * @param typeOf the {@link TypeOf} to define all generic pattern.
+	 * @param qualifier factory qualifier
+	 * @return a {@link Factory} found in the domain.
+	 */
+	<T extends Factory<A>,A extends DomainObject & Producible> T getFactory(TypeOf<T> typeOf, Class<? extends Annotation> qualifier);
+
+	/**
+	 * Get a {@link Factory} from the domain.
+	 * @param typeOf the {@link TypeOf} to define all generic pattern.
+	 * @param qualifier factory qualifier
+	 * @return a {@link Factory} found in the domain.
+	 */
+	<T extends Factory<A>,A extends DomainObject & Producible> T getFactory(TypeOf<T> typeOf, String qualifier);
+
+	/**
+	 * Get a {@link Service} from the domain.
+	 * @param rawType the service class.
+	 * @return a {@link Service} found in the domain.
+	 */
+	<T> T getService(Class<T> rawType);
+
+	/**
+	 * Get a {@link Service} with a qualifier from the domain.
+	 * @param rawType the service class.
+	 * @param qualifier service qualifier
+	 * @return a {@link Service} found in the domain.
+	 */
+	<T> T getService(Class<T> rawType, Class<? extends Annotation> qualifier);
+
+	/**
+	 * Get a {@link Service} with a qualifier from the domain.
+	 * @param rawType the service class.
+	 * @param qualifier service qualifier
+	 * @return a {@link Service} found in the domain.
+	 */
+	<T> T getService(Class<T> rawType, String qualifier);
+
+	/**
+	 * Get a {@link Service} from the domain.
+	 * @param typeOf the {@link TypeOf} to define all generic pattern.
+	 * @return a {@link Service} found in the domain.
+	 */
+	<T> T getService(TypeOf<T> typeOf);
+	
+	/**
+	 * Get a {@link Service} from the domain.
+	 * @param typeOf the {@link TypeOf} to define all generic pattern.
+	 * @param qualifier service qualifier
+	 * @return a {@link Service} found in the domain.
+	 */
+	<T> T getService(TypeOf<T> typeOf, Class<? extends Annotation> qualifier);
+
+	/**
+	 * Get a {@link Service} from the domain.
+	 * @param typeOf the {@link TypeOf} to define all generic pattern.
+	 * @param qualifier service qualifier
+	 * @return a {@link Service} found in the domain.
+	 */
+	<T> T getService(TypeOf<T> typeOf, String qualifier);
+
+	/**
+	 * Get a {@link DomainPolicy} from the domain.
+	 * @param rawType the policy class.
+	 * @return a {@link DomainPolicy} found in the domain.
+	 */
+	<T> T getPolicy(Class<T> rawType);
+
+	/**
+	 * Get a {@link DomainPolicy} with a qualifier from the domain.
+	 * @param rawType the policy class.
+	 * @param qualifier policy qualifier
+	 * @return a {@link DomainPolicy} found in the domain.
+	 */
+	<T> T getPolicy(Class<T> rawType, Class<? extends Annotation> qualifier);
+
+	/**
+	 * Get a {@link DomainPolicy} with a qualifier from the domain.
+	 * @param rawType the policy class.
+	 * @param qualifier policy qualifier
+	 * @return a {@link DomainPolicy} found in the domain.
+	 */
+	<T> T getPolicy(Class<T> rawType, String qualifier);
+
+	/**
+	 * Get a {@link DomainPolicy} from the domain.
+	 * @param typeOf the {@link TypeOf} to define all generic pattern.
+	 * @return a {@link DomainPolicy} found in the domain.
+	 */
+	<T> T getPolicy(TypeOf<T> typeOf);
+	
+	/**
+	 * Get a {@link DomainPolicy} from the domain.
+	 * @param typeOf the {@link TypeOf} to define all generic pattern.
+	 * @param qualifier policy qualifier
+	 * @return a {@link DomainPolicy} found in the domain.
+	 */
+	<T> T getPolicy(TypeOf<T> typeOf, Class<? extends Annotation> qualifier);
+
+	/**
+	 * Get a {@link DomainPolicy} from the domain.
+	 * @param typeOf the {@link TypeOf} to define all generic pattern.
+	 * @param qualifier policy qualifier
+	 * @return a {@link DomainPolicy} found in the domain.
+	 */
+	<T> T getPolicy(TypeOf<T> typeOf, String qualifier);
+}


### PR DESCRIPTION
Closed #5 

Feature to get a domain object programatically.

``` java
@Inject
DomainRegistry domain;
```

``` java
BonusCalculationPolicy myPolicy = domain.getPolicy(BonusCalculationPolicy.class, "qualifier-1");
AnotherPolicy<Client<Long>> myPolicy = domain.getPolicy(new TypeOf<AnotherPolicy<Client<Long>>>(){}, "qualifier-1");

RegistrationService myService = domain.getService(RegistrationService.class, "qualifier-1");

CustomerFactory<Customer> myFactory = domain.getFactory(Customer.class, "qualifier-1");

CustomerRepository<Customer,Long> myRepository = domain.getRepository(Customer.class, Long.class, aQualifierAnnotation.class);
```
