### PR TITLE
Add a BaseRangeFinder

### DIFF
--- a/specs/src/main/java/org/seedstack/business/finder/BaseRangeFinder.java
+++ b/specs/src/main/java/org/seedstack/business/finder/BaseRangeFinder.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2013-2015, The SeedStack authors <http://seedstack.org>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.seedstack.business.finder;
+
+import java.util.List;
+
+/**
+ * A base finder providing a simple pagination mechanism.
+ *
+ * @param <T> the type of the items to return
+ * @param <C> the type of criteria used to filter
+ */
+public abstract class BaseRangeFinder<T, C> implements RangeFinder<T, C> {
+
+    @Override
+    public Result<T> find(Range range, C criteria) {
+        long resultSize = computeFullRequestSize(criteria);
+        List<T> list = computeResultList(range, criteria);
+        return new Result<T>(list, range.getOffset(), resultSize);
+    }
+
+    /**
+     * Returns a sub list of items corresponding to the required range and criteria.
+     *
+     * @param range    the range
+     * @param criteria the criteria
+     * @return the sub list of item
+     */
+    protected abstract List<T> computeResultList(Range range, C criteria);
+
+    /**
+     * Returns the total number of items available.
+     *
+     * @param criteria the request criteria
+     * @return the total number of item
+     */
+    protected abstract long computeFullRequestSize(C criteria);
+    
+}

--- a/specs/src/test/java/org/seedstack/business/finder/BaseRangeFinderTest.java
+++ b/specs/src/test/java/org/seedstack/business/finder/BaseRangeFinderTest.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) 2013-2015, The SeedStack authors <http://seedstack.org>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package org.seedstack.business.finder;
+
+import com.google.common.collect.Lists;
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author pierre.thirouin@ext.mpsa.com (Pierre Thirouin)
+ */
+public class BaseRangeFinderTest {
+
+    @Test
+    public void testFind() throws Exception {
+        MyRangeFinder myRangeFinder = new MyRangeFinder();
+        Result<String> result = myRangeFinder.find(new Range(0,2), "o");
+        Assertions.assertThat(result.getResult()).hasSize(2);
+        Assertions.assertThat(result.getResult()).containsOnly("john", "doe");
+    }
+
+    @Test
+    public void testFindWithOffset() throws Exception {
+        MyRangeFinder myRangeFinder = new MyRangeFinder();
+        Result<String> result = myRangeFinder.find(new Range(1,2), "o");
+        Assertions.assertThat(result.getResult()).hasSize(2);
+        Assertions.assertThat(result.getResult()).containsOnly("doe", "bob");
+    }
+
+    private class MyRangeFinder extends BaseRangeFinder<String, String> {
+
+        private List<String> names = Lists.newArrayList("john", "doe", "jane", "bob", "martin");
+
+        @Override
+        protected List<String> computeResultList(Range range, String criteria) {
+            List<String> results = new ArrayList<String>();
+            int count = 0;
+            for (String name : names) {
+                if (count++ < range.getOffset())
+                    continue;
+
+                if (name.contains(criteria))
+                    results.add(name);
+
+                if (results.size() == range.getSize())
+                    break;
+            }
+            return results;
+        }
+
+        @Override
+        protected long computeFullRequestSize(String criteria) {
+            int count = 0;
+            for (String name : names) {
+                if (name.contains(criteria))
+                    count++;
+            }
+            return count;
+        }
+    }
+}


### PR DESCRIPTION
It was before [specific to JPA](https://github.com/seedstack/jpa-addon/blob/bc95ea355ee5bb56d116dd45eaf26b60f0202829/src/main/java/org/seedstack/jpa/BaseJpaRangeFinder.java), but the dependency was not really necessary.

So this PR add it back to the Business.
