### PR TITLE
Remove Comparable on BaseValueObject class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
-# Version 2.2.1 (?)
+# Version 2.3.0 (?)
 
 * [chg] The `business-web` module has been merged into `business-core` module (the dependency can be safely removed from your poms).
+* [chg] `serialVersionUID` of event classes (`org.seedstack.business.domain.events` package) has been changed to 1L.
+* [brk] The `Comparable` interface have been removed from `BaseValueObject`
 
 # Version 2.2.0 (2016-01-21)
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.seedstack.business</groupId>
         <artifactId>business</artifactId>
-        <version>2.2.1-SNAPSHOT</version>
+        <version>2.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>business-core</artifactId>

--- a/core/src/test/java/org/seedstack/business/fixtures/domain/activation/ActivationException.java
+++ b/core/src/test/java/org/seedstack/business/fixtures/domain/activation/ActivationException.java
@@ -9,11 +9,4 @@ package org.seedstack.business.fixtures.domain.activation;
 
 public class ActivationException extends Exception {
 
-	
-	
-	/**
-	 * 
-	 */
-	private static final long serialVersionUID = 1L;
-
 }

--- a/core/src/test/java/org/seedstack/business/fixtures/domain/customer/Address.java
+++ b/core/src/test/java/org/seedstack/business/fixtures/domain/customer/Address.java
@@ -48,5 +48,4 @@ public class Address extends BaseValueObject {
 		return country;
 	}
 
-	private static final long serialVersionUID = -1001839378447878324L;
 }

--- a/core/src/test/java/org/seedstack/business/fixtures/domain/customer/CustomerId.java
+++ b/core/src/test/java/org/seedstack/business/fixtures/domain/customer/CustomerId.java
@@ -26,6 +26,4 @@ public class CustomerId extends BaseValueObject{
 		return customerId;
 	}
     
-	private static final long serialVersionUID = -1001839378447878324L;
-	
 }

--- a/core/src/test/java/org/seedstack/business/fixtures/domain/order/OrderId.java
+++ b/core/src/test/java/org/seedstack/business/fixtures/domain/order/OrderId.java
@@ -12,10 +12,6 @@ import org.seedstack.business.domain.BaseValueObject;
 
 public class OrderId extends BaseValueObject {
 
-	
-	private static final long serialVersionUID = 8814444144705792621L;
-	
-	
 	private String value;
     
      OrderId()

--- a/core/src/test/java/org/seedstack/business/fixtures/domain/order/OrderItem.java
+++ b/core/src/test/java/org/seedstack/business/fixtures/domain/order/OrderItem.java
@@ -52,7 +52,5 @@ public class OrderItem extends BaseEntity<Long>
 	public void setProductId(ProductId productId) {
 		this.productId = productId;
 	}
-	private static final long serialVersionUID = -7687748254687098576L;
-
 
 }

--- a/core/src/test/java/org/seedstack/business/fixtures/domain/product/ProductId.java
+++ b/core/src/test/java/org/seedstack/business/fixtures/domain/product/ProductId.java
@@ -40,6 +40,4 @@ public class ProductId extends BaseValueObject
 		return productCode;
 	}
 	
-	private static final long serialVersionUID = 3197639858625317175L;
-	
 }

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>org.seedstack.business</groupId>
     <artifactId>business</artifactId>
-    <version>2.2.1-SNAPSHOT</version>
+    <version>2.3.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>business</name>
 
@@ -74,6 +74,18 @@
                             <licenseMerge>MIT|MIT License</licenseMerge>
                             <licenseMerge>IGNORED_LICENSE|Eclipse Public License - v 1.0</licenseMerge>
                         </licenseMerges>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>com.github.siom79.japicmp</groupId>
+                    <artifactId>japicmp-maven-plugin</artifactId>
+                    <configuration>
+                        <parameter>
+                            <excludes>
+                                <exclude>*.internal.*</exclude>
+                                <exclude>org.seedstack.business.domain.BaseValueObject</exclude>
+                            </excludes>
+                        </parameter>
                     </configuration>
                 </plugin>
             </plugins>

--- a/specs/pom.xml
+++ b/specs/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.seedstack.business</groupId>
         <artifactId>business</artifactId>
-        <version>2.2.1-SNAPSHOT</version>
+        <version>2.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>business-specs</artifactId>

--- a/specs/src/main/java/org/seedstack/business/domain/BaseValueObject.java
+++ b/specs/src/main/java/org/seedstack/business/domain/BaseValueObject.java
@@ -7,7 +7,10 @@
  */
 package org.seedstack.business.domain;
 
-import org.apache.commons.lang.builder.*;
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
+import org.apache.commons.lang.builder.ToStringBuilder;
+import org.apache.commons.lang.builder.ToStringStyle;
 
 import java.io.Serializable;
 
@@ -15,14 +18,12 @@ import java.io.Serializable;
  * This class is the inheritance base for ValueObject implementations. It offers specific {@code equals()} and
  * {@code hashCode()} methods.
  */
-public abstract class BaseValueObject implements ValueObject, Serializable, Comparable<BaseValueObject> {
+public abstract class BaseValueObject implements ValueObject, Serializable {
 
-    private static final long serialVersionUID = -6131435316889092990L;
+    private transient int cachedHashCode;
 
-	private transient int cachedHashCode;
-
-	protected BaseValueObject() {
-	}
+    protected BaseValueObject() {
+    }
 
     /**
      * @return Hash code built from all non-transient fields.
@@ -67,11 +68,5 @@ public abstract class BaseValueObject implements ValueObject, Serializable, Comp
     public String toString() {
         return ToStringBuilder.reflectionToString(this, ToStringStyle.DEFAULT_STYLE, false);
     }
-
-
-    @Override
-	public int compareTo(BaseValueObject o) {
-		return CompareToBuilder.reflectionCompare(this, o);
-	}
 
 }

--- a/specs/src/main/java/org/seedstack/business/domain/events/AggregateDeletedEvent.java
+++ b/specs/src/main/java/org/seedstack/business/domain/events/AggregateDeletedEvent.java
@@ -25,10 +25,6 @@ import java.lang.reflect.Method;
  * @author pierre.thirouin@ext.mpsa.com
  */
 public class AggregateDeletedEvent extends BaseAggregateEvent {
-
-    /**
-     *
-     */
     private static final long serialVersionUID = 1L;
 
     /**

--- a/specs/src/main/java/org/seedstack/business/domain/events/AggregatePersistedEvent.java
+++ b/specs/src/main/java/org/seedstack/business/domain/events/AggregatePersistedEvent.java
@@ -25,8 +25,7 @@ import java.lang.reflect.Method;
  * @author pierre.thirouin@ext.mpsa.com
  */
 public class AggregatePersistedEvent extends BaseAggregateEvent {
-
-    private static final long serialVersionUID = 4710766369957116577L;
+    private static final long serialVersionUID = 1L;
 
     /**
      * Constructor.

--- a/specs/src/main/java/org/seedstack/business/domain/events/AggregateReadEvent.java
+++ b/specs/src/main/java/org/seedstack/business/domain/events/AggregateReadEvent.java
@@ -25,8 +25,7 @@ import java.lang.reflect.Method;
  * @author pierre.thirouin@ext.mpsa.com
  */
 public class AggregateReadEvent extends BaseAggregateEvent {
-
-    private static final long serialVersionUID = 8010048916752719639L;
+    private static final long serialVersionUID = 1L;
 
     /**
      * Constructor.

--- a/specs/src/main/java/org/seedstack/business/domain/events/BaseAggregateEvent.java
+++ b/specs/src/main/java/org/seedstack/business/domain/events/BaseAggregateEvent.java
@@ -25,10 +25,9 @@ import java.lang.reflect.Method;
  */
 public abstract class BaseAggregateEvent extends DomainEvent {
 
+    private static final long serialVersionUID = 1L;
 
-	private static final long serialVersionUID = 4247250155695647756L;
-
-	private final Class<? extends AggregateRoot<?>> aggregateRoot;
+    private final Class<? extends AggregateRoot<?>> aggregateRoot;
 
     private final Context context;
 

--- a/specs/src/main/java/org/seedstack/business/domain/events/DomainEvent.java
+++ b/specs/src/main/java/org/seedstack/business/domain/events/DomainEvent.java
@@ -29,5 +29,5 @@ import org.seedstack.business.domain.BaseValueObject;
 public abstract class DomainEvent extends BaseValueObject implements Event {
 
 	/***/
-	private static final long serialVersionUID = 4411433793175516909L;
+	private static final long serialVersionUID = 1L;
 }

--- a/specs/src/main/java/org/seedstack/business/view/AbstractView.java
+++ b/specs/src/main/java/org/seedstack/business/view/AbstractView.java
@@ -18,9 +18,6 @@ import java.util.List;
  * @author epo.jemba@ext.mpsa.com
  */
 public abstract class AbstractView<Item> implements View<Item> {
-
-    private static final long serialVersionUID = 5881361314603724860L;
-
     protected final VirtualList<Item> resultList;
     protected final long resultSize;
     protected final long resultViewOffset;

--- a/specs/src/main/java/org/seedstack/business/view/ChunkedView.java
+++ b/specs/src/main/java/org/seedstack/business/view/ChunkedView.java
@@ -19,9 +19,6 @@ import java.util.List;
  * @author epo.jemba@ext.mpsa.com
  */
 public class ChunkedView<T> extends AbstractView<T> {
-
-    private static final long serialVersionUID = -1243841856843942270L;
-
     /**
      * Constructor.
      *

--- a/specs/src/main/java/org/seedstack/business/view/PaginatedView.java
+++ b/specs/src/main/java/org/seedstack/business/view/PaginatedView.java
@@ -19,8 +19,6 @@ import java.util.List;
  */
 public class PaginatedView<Item> extends AbstractView<Item> {
 
-    private static final long serialVersionUID = 8025757060932521691L;
-
     private final long pageIndex;
 
     private final long pagesCount;


### PR DESCRIPTION
This Comparable interface should be implemented by extending classes as it is business-dependent but it is prevented by the fact that Comparable is already implemented with the <BaseValueObject> generic parameter.
