### PR TITLE
Add Repository methods, minor fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Version 2.3.0 (?)
 
+* [new] Add methods `exists()`, `count()` and `clear()` on `Repository`
+* [brk] The `Comparable` interface have been removed from `BaseValueObject`
+* [brk] Methods `do*()` on `BaseRepository` have been removed. Directly implement their matching method on `Repository`.
+* [brk] Removed `dtoClass` protected field on `ModelMapperAssembler` and `ModelMapperTupleAssembler`. Use `getDtoClass()` accessor instead.
+* [brk] Made `dtoClass` field on `AbstractBaseAssembler` private. Use `getDtoClass()` accessor instead.
 * [chg] The `business-web` module has been merged into `business-core` module (the dependency can be safely removed from your poms).
 * [chg] `serialVersionUID` of event classes (`org.seedstack.business.domain.events` package) has been changed to 1L.
-* [brk] The `Comparable` interface have been removed from `BaseValueObject`
 
 # Version 2.2.0 (2016-01-21)
 

--- a/core/src/it/java/org/seedstack/business/assembler/auto/fixture/DummyDefaultAssembler.java
+++ b/core/src/it/java/org/seedstack/business/assembler/auto/fixture/DummyDefaultAssembler.java
@@ -8,9 +8,9 @@
 package org.seedstack.business.assembler.auto.fixture;
 
 import com.google.inject.assistedinject.Assisted;
-import org.seedstack.business.spi.GenericImplementation;
-import org.seedstack.business.domain.AggregateRoot;
 import org.seedstack.business.assembler.AbstractBaseAssembler;
+import org.seedstack.business.domain.AggregateRoot;
+import org.seedstack.business.spi.GenericImplementation;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -21,13 +21,12 @@ import java.lang.reflect.Method;
  */
 @GenericImplementation
 @Named("Dummy")
-public class DummyDefaultAssembler<A extends AggregateRoot<?>,D> extends AbstractBaseAssembler<A, D> {
-
+public class DummyDefaultAssembler<A extends AggregateRoot<?>, D> extends AbstractBaseAssembler<A, D> {
 
     @SuppressWarnings("unchecked")
     @Inject
     public DummyDefaultAssembler(@Assisted Object[] genericClasses) {
-        dtoClass = (Class) genericClasses.clone()[1];
+        super((Class) genericClasses.clone()[1]);
     }
 
     @Override

--- a/core/src/it/java/org/seedstack/business/assembler/dsl/AssemblerDslIT.java
+++ b/core/src/it/java/org/seedstack/business/assembler/dsl/AssemblerDslIT.java
@@ -11,19 +11,17 @@ import org.assertj.core.api.Assertions;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.seedstack.business.domain.Repository;
 import org.seedstack.business.assembler.AssemblerTypes;
 import org.seedstack.business.assembler.FluentAssembler;
+import org.seedstack.business.domain.Repository;
 import org.seedstack.business.internal.assembler.dsl.fixture.auto.BasicAggregate;
 import org.seedstack.business.internal.assembler.dsl.fixture.auto.BasicDto;
 import org.seedstack.business.internal.assembler.dsl.fixture.customer.Order;
 import org.seedstack.business.internal.assembler.dsl.fixture.customer.OrderDto;
 import org.seedstack.business.internal.assembler.dsl.fixture.customer.OrderFactory;
-import org.seedstack.business.internal.assembler.dsl.fixture.customer.OrderRepositoryInternal;
 import org.seedstack.seed.it.SeedITRunner;
 
 import javax.inject.Inject;
-
 import java.util.UUID;
 
 import static junit.framework.TestCase.fail;
@@ -47,7 +45,7 @@ public class AssemblerDslIT {
 
     @Before
     public void before() {
-        ((OrderRepositoryInternal)orderRepository).doClear();
+        orderRepository.clear();
     }
 
     @Test

--- a/core/src/it/java/org/seedstack/business/events/AggregateEventIT.java
+++ b/core/src/it/java/org/seedstack/business/events/AggregateEventIT.java
@@ -52,13 +52,13 @@ public class AggregateEventIT {
         @Override
         public void handle(BaseAggregateEvent event) {
             Assertions.assertThat(logger).isNotNull();
-            if (event.getContext().getMethodCalled().getName().equals("doLoad") || event.getContext().getMethodCalled().getName().equals("doDelete")) {
+            if (event.getContext().getMethodCalled().getName().equals("load") || event.getContext().getMethodCalled().getName().equals("delete")) {
                 Object o = event.getContext().getArgs()[0];
                 if (ProductId.class.isAssignableFrom(o.getClass())) {
                     receivedId = (ProductId) o;
                 }
             }
-            if (event.getContext().getMethodCalled().getName().equals("doSave") || event.getContext().getMethodCalled().getName().equals("doPersist")) {
+            if (event.getContext().getMethodCalled().getName().equals("save") || event.getContext().getMethodCalled().getName().equals("persist")) {
                 Object o = event.getContext().getArgs()[0];
                 if (Product.class.isAssignableFrom(o.getClass())) {
                     receivedAggregate = (Product) o;
@@ -84,7 +84,7 @@ public class AggregateEventIT {
     @Test
     public void base_repository_event_was_received() {
         productRepository.persist(product);
-        Assertions.assertThat(product).isEqualTo(receivedAggregate);
+        Assertions.assertThat(receivedAggregate).isEqualTo(product);
 
         ProductId id = new ProductId(Short.MIN_VALUE, "pok");
         productRepository.load(id);

--- a/core/src/it/java/org/seedstack/business/internal/registry/repository/ClientRepository.java
+++ b/core/src/it/java/org/seedstack/business/internal/registry/repository/ClientRepository.java
@@ -21,28 +21,38 @@ import org.seedstack.business.spi.GenericImplementation;
 public class ClientRepository<A extends AggregateRoot<K>, K> extends BaseRepository<A, K>{
 
 	@Override
-	protected A doLoad(K id) {
+	public A load(K id) {
 		return null;
 	}
 
 	@Override
-	protected void doClear() {
+	public boolean exists(K id) {
+		return false;
 	}
 
 	@Override
-	protected void doDelete(K id) {
+	public long count() {
+		return 0L;
 	}
 
 	@Override
-	protected void doDelete(A aggregate) {
+	public void clear() {
 	}
 
 	@Override
-	protected void doPersist(A aggregate) {
+	public void delete(K id) {
 	}
 
 	@Override
-	protected A doSave(A aggregate) {
+	public void delete(A aggregate) {
+	}
+
+	@Override
+	public void persist(A aggregate) {
+	}
+
+	@Override
+	public A save(A aggregate) {
 		return null;
 	}
 

--- a/core/src/it/java/org/seedstack/business/repositories/fixtures/DefaultRepoSample.java
+++ b/core/src/it/java/org/seedstack/business/repositories/fixtures/DefaultRepoSample.java
@@ -27,28 +27,38 @@ public class DefaultRepoSample<A extends AggregateRoot<K>, K> extends AbstractDe
     }
 
     @Override
-    protected A doLoad(K id) {
+    public A load(K id) {
         return null;
     }
 
     @Override
-    protected void doClear() {
+    public boolean exists(K id) {
+        return false;
     }
 
     @Override
-    protected void doDelete(K id) {
+    public long count() {
+        return 0L;
     }
 
     @Override
-    protected void doDelete(A a) {
+    public void clear() {
     }
 
     @Override
-    protected void doPersist(A a) {
+    public void delete(K id) {
     }
 
     @Override
-    protected A doSave(A a) {
+    public void delete(A a) {
+    }
+
+    @Override
+    public void persist(A a) {
+    }
+
+    @Override
+    public A save(A a) {
         return null;
     }
 }

--- a/core/src/it/java/org/seedstack/business/repositories/fixtures/DefaultRepoSample2.java
+++ b/core/src/it/java/org/seedstack/business/repositories/fixtures/DefaultRepoSample2.java
@@ -28,32 +28,38 @@ public class DefaultRepoSample2<A extends AggregateRoot<K>, K> extends BaseRepos
     }
 
     @Override
-    protected A doLoad(K id) {
+    public A load(K id) {
         return null;
     }
 
     @Override
-    protected void doClear() {
-
+    public boolean exists(K id) {
+        return false;
     }
 
     @Override
-    protected void doDelete(K id) {
-
+    public long count() {
+        return 0L;
     }
 
     @Override
-    protected void doDelete(A a) {
-
+    public void clear() {
     }
 
     @Override
-    protected void doPersist(A a) {
-
+    public void delete(K id) {
     }
 
     @Override
-    protected A doSave(A a) {
+    public void delete(A a) {
+    }
+
+    @Override
+    public void persist(A a) {
+    }
+
+    @Override
+    public A save(A a) {
         return null;
     }
 }

--- a/core/src/it/java/org/seedstack/business/repositories/fixtures/DefaultRepoSample3.java
+++ b/core/src/it/java/org/seedstack/business/repositories/fixtures/DefaultRepoSample3.java
@@ -27,28 +27,38 @@ public class DefaultRepoSample3<A extends AggregateRoot<K>, K> extends BaseRepos
     }
 
     @Override
-    protected A doLoad(K id) {
+    public A load(K id) {
         return null;
     }
 
     @Override
-    protected void doClear() {
+    public boolean exists(K id) {
+        return false;
     }
 
     @Override
-    protected void doDelete(K id) {
+    public long count() {
+        return 0L;
     }
 
     @Override
-    protected void doDelete(A a) {
+    public void clear() {
     }
 
     @Override
-    protected void doPersist(A a) {
+    public void delete(K id) {
     }
 
     @Override
-    protected A doSave(A a) {
+    public void delete(A a) {
+    }
+
+    @Override
+    public void persist(A a) {
+    }
+
+    @Override
+    public A save(A a) {
         return null;
     }
 }

--- a/core/src/main/java/org/seedstack/business/assembler/modelmapper/ModelMapperAssembler.java
+++ b/core/src/main/java/org/seedstack/business/assembler/modelmapper/ModelMapperAssembler.java
@@ -28,8 +28,8 @@ public abstract class ModelMapperAssembler<A extends AggregateRoot<?>, D> extend
     }
 
     public ModelMapperAssembler(Class<D> dtoClass) {
+        super(dtoClass);
         initModelMappers();
-        this.dtoClass = dtoClass;
     }
 
     @Override

--- a/core/src/main/java/org/seedstack/business/assembler/modelmapper/ModelMapperTupleAssembler.java
+++ b/core/src/main/java/org/seedstack/business/assembler/modelmapper/ModelMapperTupleAssembler.java
@@ -7,12 +7,9 @@
  */
 package org.seedstack.business.assembler.modelmapper;
 
-import net.jodah.typetools.TypeResolver;
 import org.javatuples.Tuple;
 import org.modelmapper.ModelMapper;
 import org.seedstack.business.assembler.AbstractBaseAssembler;
-import org.seedstack.business.assembler.BaseTupleAssembler;
-import org.seedstack.seed.core.utils.SeedReflectionUtils;
 
 /**
  * This assembler automatically assembles aggregates in DTO and vice versa.
@@ -22,22 +19,17 @@ import org.seedstack.seed.core.utils.SeedReflectionUtils;
  * @author pierre.thirouin@ext.mpsa.com (Pierre Thirouin)
  */
 public abstract class ModelMapperTupleAssembler<T extends Tuple, D> extends AbstractBaseAssembler<T, D> {
-
-    protected Class<D> dtoClass;
     private ModelMapper assembleModelMapper;
     private ModelMapper mergeModelMapper;
 
     @SuppressWarnings({"unchecked", "rawtypes"})
     public ModelMapperTupleAssembler() {
         initModelMappers();
-
-        Class<? extends BaseTupleAssembler> class1 = (Class<? extends BaseTupleAssembler>) SeedReflectionUtils.cleanProxy(getClass());
-        dtoClass = (Class<D>) TypeResolver.resolveRawArguments(class1.getGenericSuperclass(), class1)[1];
     }
 
     public ModelMapperTupleAssembler(Class<D> dtoClass) {
+        super(dtoClass);
         initModelMappers();
-        this.dtoClass = dtoClass;
     }
 
     @Override
@@ -68,7 +60,7 @@ public abstract class ModelMapperTupleAssembler<T extends Tuple, D> extends Abst
         }
     }
 
-    void initModelMappers() {
+    private void initModelMappers() {
         this.assembleModelMapper = new ModelMapper();
         configureAssembly(assembleModelMapper);
 

--- a/core/src/main/java/org/seedstack/business/internal/utils/BusinessReflectUtils.java
+++ b/core/src/main/java/org/seedstack/business/internal/utils/BusinessReflectUtils.java
@@ -21,7 +21,7 @@ public final class BusinessReflectUtils {
 
     public static Class<?> getAggregateIdClass(Class<? extends AggregateRoot<?>> aggregateRootClass) {
         SeedCheckUtils.checkIfNotNull(aggregateRootClass, "aggregateRootClass should not be null");
-        return TypeResolver.resolveRawArguments(aggregateRootClass.getGenericSuperclass(), aggregateRootClass)[0];
+        return TypeResolver.resolveRawArguments(TypeResolver.resolveGenericType(AggregateRoot.class, aggregateRootClass), aggregateRootClass)[0];
     }
 
 }

--- a/core/src/test/java/org/seedstack/business/fixtures/InMemoryRepository.java
+++ b/core/src/test/java/org/seedstack/business/fixtures/InMemoryRepository.java
@@ -45,33 +45,43 @@ public class InMemoryRepository<Aggregate extends AggregateRoot<Key>, Key> exten
 
     @Override
     @SuppressWarnings("unchecked")
-    protected Aggregate doLoad(Key id) {
+    public Aggregate load(Key id) {
         return (Aggregate) inMemorySortedMap.get(id);
     }
 
     @Override
-    protected void doClear() {
+    public boolean exists(Key id) {
+        return inMemorySortedMap.containsKey(id);
+    }
+
+    @Override
+    public long count() {
+        return inMemorySortedMap.size();
+    }
+
+    @Override
+    public void clear() {
         inMemorySortedMap.clear();
     }
 
     @Override
-    protected void doDelete(Key id) {
+    public void delete(Key id) {
         inMemorySortedMap.remove(id);
     }
 
     @Override
-    protected void doDelete(Aggregate aggregate) {
+    public void delete(Aggregate aggregate) {
         inMemorySortedMap.remove(aggregate.getEntityId());
     }
 
     @Override
-    protected void doPersist(Aggregate aggregate) {
+    public void persist(Aggregate aggregate) {
         this.inMemorySortedMap.put(aggregate.getEntityId(), aggregate);
     }
 
     @Override
     @SuppressWarnings("unchecked")
-    protected Aggregate doSave(Aggregate aggregate) {
+    public Aggregate save(Aggregate aggregate) {
         return (Aggregate) this.inMemorySortedMap.put(aggregate.getEntityId(), aggregate);
     }
 

--- a/core/src/test/java/org/seedstack/business/internal/assembler/dsl/fixture/customer/CustomerRepositoryInternal.java
+++ b/core/src/test/java/org/seedstack/business/internal/assembler/dsl/fixture/customer/CustomerRepositoryInternal.java
@@ -20,17 +20,31 @@ public class CustomerRepositoryInternal extends BaseRepository<Customer, String>
     private static Map<String, Customer> orderMap = new ConcurrentHashMap<String, Customer>();
 
     @Override
-    protected Customer doLoad(String id) {
+    public Customer load(String id) {
         return orderMap.get(id);
     }
 
     @Override
-    protected void doDelete(String id) {
+    public boolean exists(String id) {
+        return orderMap.containsKey(id);
+    }
+
+    @Override
+    public long count() {
+        return orderMap.size();
+    }
+
+    public void clear() {
+        orderMap.clear();
+    }
+
+    @Override
+    public void delete(String id) {
         orderMap.remove(id);
     }
 
     @Override
-    protected void doDelete(Customer order) {
+    public void delete(Customer order) {
         for (Customer order1 : orderMap.values()) {
             if (order1.equals(order)) {
                 orderMap.remove(order.getEntityId());
@@ -39,16 +53,12 @@ public class CustomerRepositoryInternal extends BaseRepository<Customer, String>
     }
 
     @Override
-    protected void doPersist(Customer order) {
+    public void persist(Customer order) {
         orderMap.put(order.getEntityId(), order);
     }
 
     @Override
-    protected Customer doSave(Customer order) {
+    public Customer save(Customer order) {
         return orderMap.put(order.getEntityId(), order);
-    }
-
-    public void doClear() {
-        orderMap.clear();
     }
 }

--- a/core/src/test/java/org/seedstack/business/internal/assembler/dsl/fixture/customer/OrderRepositoryInternal.java
+++ b/core/src/test/java/org/seedstack/business/internal/assembler/dsl/fixture/customer/OrderRepositoryInternal.java
@@ -20,17 +20,31 @@ public class OrderRepositoryInternal extends BaseRepository<Order, String> imple
     private static Map<String, Order> orderMap = new ConcurrentHashMap<String, Order>();
 
     @Override
-    protected Order doLoad(String id) {
+    public Order load(String id) {
         return orderMap.get(id);
     }
 
     @Override
-    protected void doDelete(String id) {
+    public boolean exists(String id) {
+        return orderMap.containsKey(id);
+    }
+
+    @Override
+    public long count() {
+        return orderMap.size();
+    }
+
+    public void clear() {
+        orderMap.clear();
+    }
+
+    @Override
+    public void delete(String id) {
         orderMap.remove(id);
     }
 
     @Override
-    protected void doDelete(Order order) {
+    public void delete(Order order) {
         for (Order order1 : orderMap.values()) {
             if (order1.equals(order)) {
                 orderMap.remove(order.getEntityId());
@@ -39,16 +53,12 @@ public class OrderRepositoryInternal extends BaseRepository<Order, String> imple
     }
 
     @Override
-    protected void doPersist(Order order) {
+    public void persist(Order order) {
         orderMap.put(order.getEntityId(), order);
     }
 
     @Override
-    protected Order doSave(Order order) {
+    public Order save(Order order) {
         return orderMap.put(order.getEntityId(), order);
-    }
-
-    public void doClear() {
-        orderMap.clear();
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -84,8 +84,14 @@
                         <parameter>
                             <excludes>
                                 <exclude>*.internal.*</exclude>
+                                <exclude>org.seedstack.business.domain.BaseFactory</exclude>
+                                <exclude>org.seedstack.business.domain.BaseRepository</exclude>
+                                <exclude>org.seedstack.business.domain.BaseEntity</exclude>
                                 <exclude>org.seedstack.business.domain.BaseValueObject</exclude>
+                                <exclude>org.seedstack.business.domain.events.BaseAggregateEvent</exclude>
+                                <exclude>org.seedstack.business.assembler.AbstractBaseAssembler</exclude>
                                 <exclude>org.seedstack.business.assembler.modelmapper.ModelMapperAssembler</exclude>
+                                <exclude>org.seedstack.business.assembler.modelmapper.ModelMapperTupleAssembler</exclude>
                             </excludes>
                         </parameter>
                     </configuration>

--- a/specs/src/main/java/org/seedstack/business/assembler/AbstractBaseAssembler.java
+++ b/specs/src/main/java/org/seedstack/business/assembler/AbstractBaseAssembler.java
@@ -11,8 +11,6 @@ package org.seedstack.business.assembler;
 import net.jodah.typetools.TypeResolver;
 import org.seedstack.seed.core.utils.SeedReflectionUtils;
 
-import java.lang.reflect.Type;
-
 /**
  * This assembler is intended to be extended by the base assemblers not directly by the users.
  *
@@ -23,14 +21,29 @@ import java.lang.reflect.Type;
  * @see org.seedstack.business.assembler.BaseTupleAssembler
  */
 public abstract class AbstractBaseAssembler<A, D> implements Assembler<A, D> {
-    protected Class<D> dtoClass;
+    protected final Class<D> dtoClass;
 
+    /**
+     * Creates an assembler with automatic resolution of its DTO class.
+     */
     @SuppressWarnings({"unchecked", "rawtypes"})
     public AbstractBaseAssembler() {
-        Class<? extends AbstractBaseAssembler> class1 = (Class<? extends AbstractBaseAssembler>) SeedReflectionUtils.cleanProxy(getClass());
-        dtoClass = (Class<D>) TypeResolver.resolveRawArguments(getGenericType(), class1)[1];
+        Class<?> subType = SeedReflectionUtils.cleanProxy(getClass());
+        this.dtoClass = (Class<D>) TypeResolver.resolveRawArguments(TypeResolver.resolveGenericType(AbstractBaseAssembler.class, subType), subType)[1];
     }
 
+    /**
+     * Creates an assembler with the DTO class explicitly specified.
+     *
+     * @param dtoClass the DTO class.
+     */
+    protected AbstractBaseAssembler(Class<D> dtoClass) {
+        this.dtoClass = dtoClass;
+    }
+
+    /**
+     * @return the DTO class this assembler handles.
+     */
     @Override
     public Class<D> getDtoClass() {
         return this.dtoClass;
@@ -55,14 +68,5 @@ public abstract class AbstractBaseAssembler<A, D> implements Assembler<A, D> {
         }
 
         return newInstance;
-    }
-
-    private Type getGenericType() {
-        Class<?> superclass = SeedReflectionUtils.cleanProxy(getClass());
-        while (!AbstractBaseAssembler.class.equals(superclass.getSuperclass())) {
-            superclass = superclass.getSuperclass();
-        }
-
-        return superclass.getGenericSuperclass();
     }
 }

--- a/specs/src/main/java/org/seedstack/business/assembler/BaseTupleAssembler.java
+++ b/specs/src/main/java/org/seedstack/business/assembler/BaseTupleAssembler.java
@@ -8,9 +8,6 @@
 package org.seedstack.business.assembler;
 
 import org.javatuples.Tuple;
-import org.seedstack.seed.core.utils.SeedReflectionUtils;
-
-import java.lang.reflect.ParameterizedType;
 
 /**
  * This class is used by developers as bases for Tuple based assemblers.
@@ -20,16 +17,6 @@ import java.lang.reflect.ParameterizedType;
  * @author epo.jemba@ext.mpsa.com
  */
 public abstract class BaseTupleAssembler<T extends Tuple, D> extends AbstractBaseAssembler<T, D> {
-
-    /**
-     * Default needed constructor. Initialize internal private fields {@code TupleType aggregateClasses}.
-     */
-    @SuppressWarnings({"unchecked", "rawtypes"})
-    public BaseTupleAssembler() {
-        Class<? extends BaseTupleAssembler> class1 = (Class<? extends BaseTupleAssembler>) SeedReflectionUtils.cleanProxy(getClass());
-
-        dtoClass = (Class<D>) ((ParameterizedType) class1.getGenericSuperclass()).getActualTypeArguments()[1];
-    }
 
     /**
      * This method is used by developers or by {@link org.seedstack.business.assembler.FluentAssembler}

--- a/specs/src/main/java/org/seedstack/business/domain/BaseEntity.java
+++ b/specs/src/main/java/org/seedstack/business/domain/BaseEntity.java
@@ -23,6 +23,9 @@ import org.seedstack.seed.SeedException;
  */
 public abstract class BaseEntity<ID> implements Entity<ID> {
 
+    protected BaseEntity() {
+    }
+
     @Override
     public abstract ID getEntityId();
 

--- a/specs/src/main/java/org/seedstack/business/domain/BaseFactory.java
+++ b/specs/src/main/java/org/seedstack/business/domain/BaseFactory.java
@@ -7,9 +7,9 @@
  */
 package org.seedstack.business.domain;
 
+import net.jodah.typetools.TypeResolver;
 import org.seedstack.business.Producible;
-
-import java.lang.reflect.ParameterizedType;
+import org.seedstack.seed.core.utils.SeedReflectionUtils;
 
 /**
  * This class has to be extended to create a domain factory implementation. It offers the plumbing necessary
@@ -18,8 +18,8 @@ import java.lang.reflect.ParameterizedType;
  * To be a valid Domain Factory implementation, the implementation must respects the followings:
  * </p>
  * <ul>
- *   <li>implements the Domain Factory interface see {@linkplain org.seedstack.business.domain.GenericFactory}</li>
- *   <li>extends this class {@link BaseFactory}.</li>
+ * <li>implements the Domain Factory interface see {@linkplain org.seedstack.business.domain.GenericFactory}</li>
+ * <li>extends this class {@link BaseFactory}.</li>
  * </ul>
  * <pre>
  * public class ProductFactoryBase extends BaseFactory&lt;Product&gt; implements ProductFactory {
@@ -48,21 +48,17 @@ import java.lang.reflect.ParameterizedType;
  * @author epo.jemba@ext.mpsa.com
  */
 public abstract class BaseFactory<DO extends DomainObject & Producible> implements GenericFactory<DO> {
+    private final Class<DO> producedClass;
 
-    private Class<DO> producedClass;
+    @SuppressWarnings("unchecked")
+    protected BaseFactory() {
+        Class<?> subType = SeedReflectionUtils.cleanProxy(getClass());
+        producedClass = (Class<DO>) TypeResolver.resolveRawArguments(TypeResolver.resolveGenericType(BaseFactory.class, subType), subType)[0];
+    }
 
     @SuppressWarnings({"unchecked", "rawtypes"})
     @Override
     public Class<DO> getProducedClass() {
-        // TODO <pith> improve the way we get the parametrize type
-        if (this.producedClass == null) {
-            Class<? extends BaseFactory> class1 = getClass();
-            if (class1.getName().contains("EnhancerByGuice")) {
-                class1 = (Class<? extends BaseFactory>) class1.getSuperclass();
-            }
-            this.producedClass = ((Class<DO>) ((ParameterizedType) class1.getGenericSuperclass()).getActualTypeArguments()[0]);
-        }
-
         return producedClass;
     }
 

--- a/specs/src/main/java/org/seedstack/business/domain/BaseRepository.java
+++ b/specs/src/main/java/org/seedstack/business/domain/BaseRepository.java
@@ -18,12 +18,11 @@ import org.seedstack.seed.core.utils.SeedReflectionUtils;
  */
 @SuppressWarnings({"unchecked", "rawtypes"})
 public abstract class BaseRepository<AGGREGATE extends AggregateRoot<KEY>, KEY> implements Repository<AGGREGATE, KEY> {
-
     private static final int AGGREGATE_INDEX = 0;
     private static final int KEY_INDEX = 1;
 
-    protected Class<AGGREGATE> aggregateRootClass;
-    protected Class<KEY> keyClass;
+    private final Class<AGGREGATE> aggregateRootClass;
+    private final Class<KEY> keyClass;
 
     /**
      * Constructs a base repository.
@@ -32,14 +31,16 @@ public abstract class BaseRepository<AGGREGATE extends AggregateRoot<KEY>, KEY> 
      * </p>
      */
     protected BaseRepository() {
-        this.aggregateRootClass = init(AGGREGATE_INDEX);
-        this.keyClass = init(KEY_INDEX);
+        Class<?> subType = SeedReflectionUtils.cleanProxy(getClass());
+        Class<?>[] rawArguments = TypeResolver.resolveRawArguments(TypeResolver.resolveGenericType(BaseRepository.class, subType), subType);
+        this.aggregateRootClass = (Class<AGGREGATE>) rawArguments[AGGREGATE_INDEX];
+        this.keyClass = (Class<KEY>) rawArguments[KEY_INDEX];
     }
 
     /**
      * Constructs a base repository settings explicitly the aggregate root class and the key class.
      * <p>
-     * This is use when the implementation class does not resolve the generics. Since the generic
+     * This is used when the implementation class does not resolve the generics. Since the generic
      * types can't be resolve at runtime, they should be passed explicitly.
      * </p>
      *
@@ -51,12 +52,6 @@ public abstract class BaseRepository<AGGREGATE extends AggregateRoot<KEY>, KEY> 
         this.keyClass = keyClass;
     }
 
-    private <T> Class<T> init(int index) {
-        Class<? extends BaseRepository> class1 = (Class<? extends BaseRepository>) SeedReflectionUtils.cleanProxy(getClass());
-
-        return (Class<T>) TypeResolver.resolveRawArguments(class1.getGenericSuperclass(), class1)[index];
-    }
-
     @Override
     public Class<AGGREGATE> getAggregateRootClass() {
         return aggregateRootClass;
@@ -66,84 +61,4 @@ public abstract class BaseRepository<AGGREGATE extends AggregateRoot<KEY>, KEY> 
     public Class<KEY> getKeyClass() {
         return keyClass;
     }
-
-    @Override
-    public final AGGREGATE load(KEY id) {
-        return doLoad(id);
-    }
-
-    @Override
-    public void clear() {
-        doClear();
-    }
-
-    @Override
-    public final void delete(KEY id) {
-        doDelete(id);
-    }
-
-    @Override
-    public final void delete(AGGREGATE aggregate) {
-        doDelete(aggregate);
-    }
-
-    @Override
-    public final void persist(AGGREGATE aggregate) {
-        doPersist(aggregate);
-    }
-
-    @Override
-    public final AGGREGATE save(AGGREGATE aggregate) {
-        return doSave(aggregate);
-    }
-
-
-    /**
-     * Delegates the load mechanism to the infrastructure.
-     *
-     * @param id the identifier of the aggregate root to load
-     * @return the loaded aggregate
-     */
-    @Read
-    protected abstract AGGREGATE doLoad(KEY id);
-
-    /**
-     * Delegates the clear mechanism to the infrastructure.
-     */
-    @Delete
-    protected abstract void doClear();
-
-    /**
-     * Delegates the delete mechanism to the infrastructure.
-     *
-     * @param id the identifier of the aggregate root to delete
-     */
-    @Delete
-    protected abstract void doDelete(KEY id);
-
-    /**
-     * Delegates the delete mechanism to the infrastructure.
-     *
-     * @param aggregate the aggregate to delete
-     */
-    @Delete
-    protected abstract void doDelete(AGGREGATE aggregate);
-
-    /**
-     * Delegates the persist mechanism to the infrastructure.
-     *
-     * @param aggregate the aggregate to persist
-     */
-    @Persist
-    protected abstract void doPersist(AGGREGATE aggregate);
-
-    /**
-     * Delegates the save mechanism to the infrastructure.
-     *
-     * @param aggregate the aggregate to save
-     * @return the saved aggregate
-     */
-    @Persist
-    protected abstract AGGREGATE doSave(AGGREGATE aggregate);
-
 }

--- a/specs/src/main/java/org/seedstack/business/domain/BaseValueObject.java
+++ b/specs/src/main/java/org/seedstack/business/domain/BaseValueObject.java
@@ -19,7 +19,6 @@ import java.io.Serializable;
  * {@code hashCode()} methods.
  */
 public abstract class BaseValueObject implements ValueObject, Serializable {
-
     private transient int cachedHashCode;
 
     protected BaseValueObject() {

--- a/specs/src/main/java/org/seedstack/business/domain/Repository.java
+++ b/specs/src/main/java/org/seedstack/business/domain/Repository.java
@@ -44,6 +44,23 @@ public interface Repository<A extends AggregateRoot<K>, K> {
     A load(K id);
 
     /**
+     * Check that the aggregate identified by the specified key exists.
+     *
+     * @param id the aggregate key
+     * @return true if the aggregate exists, false otherwise.
+     */
+    @Read
+    boolean exists(K id);
+
+    /**
+     * Returns the number of aggregates managed by this repository.
+     *
+     * @return the number of aggregates managed by this repository.
+     */
+    @Read
+    long count();
+
+    /**
      * Deletes all aggregates from the persistence.
      */
     @Delete

--- a/specs/src/main/java/org/seedstack/business/domain/events/BaseAggregateEvent.java
+++ b/specs/src/main/java/org/seedstack/business/domain/events/BaseAggregateEvent.java
@@ -38,7 +38,7 @@ public abstract class BaseAggregateEvent extends DomainEvent {
      * @param args          arguments of the intercepted method
      * @param aggregateRoot aggregate root class concern by the event
      */
-    public BaseAggregateEvent(Method methodCalled, Object[] args, Class<? extends AggregateRoot<?>> aggregateRoot) {
+    protected BaseAggregateEvent(Method methodCalled, Object[] args, Class<? extends AggregateRoot<?>> aggregateRoot) {
         this.context = new Context(methodCalled, args.clone());
         this.aggregateRoot = aggregateRoot;
     }

--- a/specs/src/test/java/org/seedstack/business/domain/DomainSpecificationsTest.java
+++ b/specs/src/test/java/org/seedstack/business/domain/DomainSpecificationsTest.java
@@ -174,6 +174,16 @@ public class DomainSpecificationsTest {
         public A load(K id) { return null; }
 
         @Override
+        public boolean exists(K id) {
+            return false;
+        }
+
+        @Override
+        public long count() {
+            return 0L;
+        }
+
+        @Override
         public void clear() { }
 
         @Override


### PR DESCRIPTION
- [new] Add methods `exists()`, `count()` and `clear()` on `Repository`
- [brk] The `Comparable` interface have been removed from `BaseValueObject`
- [brk] Methods `do*()` on `BaseRepository` have been removed. Directly implement their matching method on `Repository`.
- [brk] Removed `dtoClass` protected field on `ModelMapperAssembler` and `ModelMapperTupleAssembler`. Use `getDtoClass()` accessor instead.
- [brk] Made `dtoClass` field on `AbstractBaseAssembler` private. Use `getDtoClass()` accessor instead.
