### PR TITLE
Full support of DSL qualifiers in FluentAssembler DSL

### DIFF
--- a/core/src/main/java/org/seedstack/business/internal/assembler/dsl/MergeMultipleAggregatesFromRepositoryImpl.java
+++ b/core/src/main/java/org/seedstack/business/internal/assembler/dsl/MergeMultipleAggregatesFromRepositoryImpl.java
@@ -8,7 +8,7 @@
 
 package org.seedstack.business.internal.assembler.dsl;
 
-import java.util.stream.Stream;
+import com.google.inject.name.Names;
 import org.seedstack.business.assembler.dsl.MergeAs;
 import org.seedstack.business.assembler.dsl.MergeFromRepository;
 import org.seedstack.business.assembler.dsl.MergeFromRepositoryOrFactory;
@@ -16,9 +16,11 @@ import org.seedstack.business.domain.AggregateNotFoundException;
 import org.seedstack.business.domain.AggregateRoot;
 import org.seedstack.business.internal.utils.BusinessUtils;
 
+import java.lang.annotation.Annotation;
+import java.util.stream.Stream;
+
 class MergeMultipleAggregatesFromRepositoryImpl<A extends AggregateRoot<I>, I, D> implements
         MergeFromRepository<MergeAs<A>>, MergeFromRepositoryOrFactory<MergeAs<A>> {
-
     private final Context context;
     private final Class<A> aggregateClass;
     private final Class<I> aggregateClassId;
@@ -37,12 +39,48 @@ class MergeMultipleAggregatesFromRepositoryImpl<A extends AggregateRoot<I>, I, D
     }
 
     @Override
+    public MergeFromRepositoryOrFactory<MergeAs<A>> fromRepository(Annotation qualifier) {
+        this.context.setRepoQualifier(qualifier);
+        return this;
+    }
+
+    @Override
+    public MergeFromRepositoryOrFactory<MergeAs<A>> fromRepository(String qualifier) {
+        this.context.setRepoQualifier(Names.named(qualifier));
+        return this;
+    }
+
+    @Override
+    public MergeFromRepositoryOrFactory<MergeAs<A>> fromRepository(Class<? extends Annotation> qualifier) {
+        this.context.setRepoQualifierClass(qualifier);
+        return this;
+    }
+
+    @Override
     public MergeAs<A> fromFactory() {
         return new MergeAsImpl<>(dtoStream.map(dto -> {
             A a = context.create(dto, aggregateClass);
             context.mergeDtoIntoAggregate(dto, a);
             return a;
         }));
+    }
+
+    @Override
+    public MergeAs<A> fromFactory(Annotation qualifier) {
+        this.context.setFactoryQualifier(qualifier);
+        return fromFactory();
+    }
+
+    @Override
+    public MergeAs<A> fromFactory(String qualifier) {
+        this.context.setFactoryQualifier(Names.named(qualifier));
+        return fromFactory();
+    }
+
+    @Override
+    public MergeAs<A> fromFactory(Class<? extends Annotation> qualifier) {
+        this.context.setFactoryQualifierClass(qualifier);
+        return fromFactory();
     }
 
     @Override
@@ -69,5 +107,23 @@ class MergeMultipleAggregatesFromRepositoryImpl<A extends AggregateRoot<I>, I, D
             context.mergeDtoIntoAggregate(dto, a);
             return a;
         }));
+    }
+
+    @Override
+    public MergeAs<A> orFromFactory(Annotation qualifier) {
+        this.context.setFactoryQualifier(qualifier);
+        return orFromFactory();
+    }
+
+    @Override
+    public MergeAs<A> orFromFactory(String qualifier) {
+        this.context.setFactoryQualifier(Names.named(qualifier));
+        return orFromFactory();
+    }
+
+    @Override
+    public MergeAs<A> orFromFactory(Class<? extends Annotation> qualifier) {
+        this.context.setFactoryQualifierClass(qualifier);
+        return orFromFactory();
     }
 }

--- a/core/src/main/java/org/seedstack/business/internal/assembler/dsl/MergeMultipleTuplesFromRepositoryImpl.java
+++ b/core/src/main/java/org/seedstack/business/internal/assembler/dsl/MergeMultipleTuplesFromRepositoryImpl.java
@@ -8,9 +8,7 @@
 
 package org.seedstack.business.internal.assembler.dsl;
 
-import static org.seedstack.business.internal.utils.BusinessUtils.getAggregateIdClasses;
-
-import java.util.stream.Stream;
+import com.google.inject.name.Names;
 import org.javatuples.Tuple;
 import org.seedstack.business.assembler.dsl.MergeAs;
 import org.seedstack.business.assembler.dsl.MergeFromRepository;
@@ -18,6 +16,11 @@ import org.seedstack.business.assembler.dsl.MergeFromRepositoryOrFactory;
 import org.seedstack.business.domain.AggregateNotFoundException;
 import org.seedstack.business.domain.AggregateRoot;
 import org.seedstack.business.util.Tuples;
+
+import java.lang.annotation.Annotation;
+import java.util.stream.Stream;
+
+import static org.seedstack.business.internal.utils.BusinessUtils.getAggregateIdClasses;
 
 class MergeMultipleTuplesFromRepositoryImpl<T extends Tuple, D> implements MergeFromRepository<MergeAs<T>>,
         MergeFromRepositoryOrFactory<MergeAs<T>> {
@@ -42,6 +45,24 @@ class MergeMultipleTuplesFromRepositoryImpl<T extends Tuple, D> implements Merge
     }
 
     @Override
+    public MergeFromRepositoryOrFactory<MergeAs<T>> fromRepository(Annotation qualifier) {
+        this.context.setRepoQualifier(qualifier);
+        return this;
+    }
+
+    @Override
+    public MergeFromRepositoryOrFactory<MergeAs<T>> fromRepository(String qualifier) {
+        this.context.setRepoQualifier(Names.named(qualifier));
+        return this;
+    }
+
+    @Override
+    public MergeFromRepositoryOrFactory<MergeAs<T>> fromRepository(Class<? extends Annotation> qualifier) {
+        this.context.setRepoQualifierClass(qualifier);
+        return this;
+    }
+
+    @Override
     public MergeAs<T> fromFactory() {
         return new MergeAsImpl<>(dtoStream.map(dto -> {
             AggregateRoot<?>[] aggregateRoots = new AggregateRoot<?>[aggregateClasses.length];
@@ -52,6 +73,24 @@ class MergeMultipleTuplesFromRepositoryImpl<T extends Tuple, D> implements Merge
             context.mergeDtoIntoTuple(dto, tuple, aggregateClasses);
             return tuple;
         }));
+    }
+
+    @Override
+    public MergeAs<T> fromFactory(Annotation qualifier) {
+        this.context.setFactoryQualifier(qualifier);
+        return fromFactory();
+    }
+
+    @Override
+    public MergeAs<T> fromFactory(String qualifier) {
+        this.context.setFactoryQualifier(Names.named(qualifier));
+        return fromFactory();
+    }
+
+    @Override
+    public MergeAs<T> fromFactory(Class<? extends Annotation> qualifier) {
+        this.context.setFactoryQualifierClass(qualifier);
+        return fromFactory();
     }
 
     @Override
@@ -88,8 +127,26 @@ class MergeMultipleTuplesFromRepositoryImpl<T extends Tuple, D> implements Merge
         }));
     }
 
+    @Override
+    public MergeAs<T> orFromFactory(Annotation qualifier) {
+        this.context.setFactoryQualifier(qualifier);
+        return orFromFactory();
+    }
+
+    @Override
+    public MergeAs<T> orFromFactory(String qualifier) {
+        this.context.setFactoryQualifier(Names.named(qualifier));
+        return orFromFactory();
+    }
+
+    @Override
+    public MergeAs<T> orFromFactory(Class<? extends Annotation> qualifier) {
+        this.context.setFactoryQualifierClass(qualifier);
+        return orFromFactory();
+    }
+
     @SuppressWarnings("unchecked")
-    private <A extends AggregateRoot<I>, I> AggregateRoot<?> load(Object id,
+    private <A extends AggregateRoot<I>, I> A load(Object id,
             Class<? extends AggregateRoot<?>> aggregateClass) {
         return context.load((I) id, (Class<A>) aggregateClass);
     }

--- a/core/src/main/java/org/seedstack/business/internal/assembler/dsl/MergeSingleAggregateFromRepositoryImpl.java
+++ b/core/src/main/java/org/seedstack/business/internal/assembler/dsl/MergeSingleAggregateFromRepositoryImpl.java
@@ -8,11 +8,13 @@
 
 package org.seedstack.business.internal.assembler.dsl;
 
-import java.util.stream.Stream;
 import org.seedstack.business.assembler.dsl.MergeFromRepository;
 import org.seedstack.business.assembler.dsl.MergeFromRepositoryOrFactory;
 import org.seedstack.business.domain.AggregateNotFoundException;
 import org.seedstack.business.domain.AggregateRoot;
+
+import java.lang.annotation.Annotation;
+import java.util.stream.Stream;
 
 class MergeSingleAggregateFromRepositoryImpl<A extends AggregateRoot<I>, I, D> implements MergeFromRepository<A>,
         MergeFromRepositoryOrFactory<A> {
@@ -25,12 +27,58 @@ class MergeSingleAggregateFromRepositoryImpl<A extends AggregateRoot<I>, I, D> i
 
     @Override
     public MergeFromRepositoryOrFactory<A> fromRepository() {
+        // no call because no qualifier to set (see below)
+        return this;
+    }
+
+    @Override
+    public MergeFromRepositoryOrFactory<A> fromRepository(Annotation qualifier) {
+        // keep the call below for the side-effect of setting the qualifier in the DSL context
+        multipleMerger.fromRepository(qualifier);
+        return this;
+    }
+
+    @Override
+    public MergeFromRepositoryOrFactory<A> fromRepository(String qualifier) {
+        // keep the call below for the side-effect of setting the qualifier in the DSL context
+        multipleMerger.fromRepository(qualifier);
+        return this;
+    }
+
+    @Override
+    public MergeFromRepositoryOrFactory<A> fromRepository(Class<? extends Annotation> qualifier) {
+        // keep the call below for the side-effect of setting the qualifier in the DSL context
+        multipleMerger.fromRepository(qualifier);
         return this;
     }
 
     @Override
     public A fromFactory() {
         return multipleMerger.fromFactory()
+                .asStream()
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException("Nothing to merge"));
+    }
+
+    @Override
+    public A fromFactory(Annotation qualifier) {
+        return multipleMerger.fromFactory(qualifier)
+                .asStream()
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException("Nothing to merge"));
+    }
+
+    @Override
+    public A fromFactory(String qualifier) {
+        return multipleMerger.fromFactory(qualifier)
+                .asStream()
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException("Nothing to merge"));
+    }
+
+    @Override
+    public A fromFactory(Class<? extends Annotation> qualifier) {
+        return multipleMerger.fromFactory(qualifier)
                 .asStream()
                 .findFirst()
                 .orElseThrow(() -> new IllegalStateException("Nothing to merge"));
@@ -47,6 +95,30 @@ class MergeSingleAggregateFromRepositoryImpl<A extends AggregateRoot<I>, I, D> i
     @Override
     public A orFromFactory() {
         return multipleMerger.orFromFactory()
+                .asStream()
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException("Nothing to merge"));
+    }
+
+    @Override
+    public A orFromFactory(Annotation qualifier) {
+        return multipleMerger.orFromFactory(qualifier)
+                .asStream()
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException("Nothing to merge"));
+    }
+
+    @Override
+    public A orFromFactory(String qualifier) {
+        return multipleMerger.orFromFactory(qualifier)
+                .asStream()
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException("Nothing to merge"));
+    }
+
+    @Override
+    public A orFromFactory(Class<? extends Annotation> qualifier) {
+        return multipleMerger.orFromFactory(qualifier)
                 .asStream()
                 .findFirst()
                 .orElseThrow(() -> new IllegalStateException("Nothing to merge"));

--- a/core/src/main/java/org/seedstack/business/internal/assembler/dsl/MergeSingleTupleFromRepositoryImpl.java
+++ b/core/src/main/java/org/seedstack/business/internal/assembler/dsl/MergeSingleTupleFromRepositoryImpl.java
@@ -8,12 +8,14 @@
 
 package org.seedstack.business.internal.assembler.dsl;
 
-import java.util.stream.Stream;
 import org.javatuples.Tuple;
 import org.seedstack.business.assembler.dsl.MergeFromRepository;
 import org.seedstack.business.assembler.dsl.MergeFromRepositoryOrFactory;
 import org.seedstack.business.domain.AggregateNotFoundException;
 import org.seedstack.business.domain.AggregateRoot;
+
+import java.lang.annotation.Annotation;
+import java.util.stream.Stream;
 
 class MergeSingleTupleFromRepositoryImpl<T extends Tuple, D> implements MergeFromRepository<T>,
         MergeFromRepositoryOrFactory<T> {
@@ -27,12 +29,58 @@ class MergeSingleTupleFromRepositoryImpl<T extends Tuple, D> implements MergeFro
 
     @Override
     public MergeFromRepositoryOrFactory<T> fromRepository() {
+        // no call because no qualifier to set (see below)
+        return this;
+    }
+
+    @Override
+    public MergeFromRepositoryOrFactory<T> fromRepository(Annotation qualifier) {
+        // keep the call below for the side-effect of setting the qualifier in the DSL context
+        multipleMerger.fromRepository(qualifier);
+        return this;
+    }
+
+    @Override
+    public MergeFromRepositoryOrFactory<T> fromRepository(String qualifier) {
+        // keep the call below for the side-effect of setting the qualifier in the DSL context
+        multipleMerger.fromRepository(qualifier);
+        return this;
+    }
+
+    @Override
+    public MergeFromRepositoryOrFactory<T> fromRepository(Class<? extends Annotation> qualifier) {
+        // keep the call below for the side-effect of setting the qualifier in the DSL context
+        multipleMerger.fromRepository(qualifier);
         return this;
     }
 
     @Override
     public T fromFactory() {
         return multipleMerger.fromFactory()
+                .asStream()
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException("Nothing to merge"));
+    }
+
+    @Override
+    public T fromFactory(Annotation qualifier) {
+        return multipleMerger.fromFactory(qualifier)
+                .asStream()
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException("Nothing to merge"));
+    }
+
+    @Override
+    public T fromFactory(String qualifier) {
+        return multipleMerger.fromFactory(qualifier)
+                .asStream()
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException("Nothing to merge"));
+    }
+
+    @Override
+    public T fromFactory(Class<? extends Annotation> qualifier) {
+        return multipleMerger.fromFactory(qualifier)
                 .asStream()
                 .findFirst()
                 .orElseThrow(() -> new IllegalStateException("Nothing to merge"));
@@ -49,6 +97,30 @@ class MergeSingleTupleFromRepositoryImpl<T extends Tuple, D> implements MergeFro
     @Override
     public T orFromFactory() {
         return multipleMerger.orFromFactory()
+                .asStream()
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException("Nothing to merge"));
+    }
+
+    @Override
+    public T orFromFactory(Annotation qualifier) {
+        return multipleMerger.orFromFactory(qualifier)
+                .asStream()
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException("Nothing to merge"));
+    }
+
+    @Override
+    public T orFromFactory(String qualifier) {
+        return multipleMerger.orFromFactory(qualifier)
+                .asStream()
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException("Nothing to merge"));
+    }
+
+    @Override
+    public T orFromFactory(Class<? extends Annotation> qualifier) {
+        return multipleMerger.orFromFactory(qualifier)
                 .asStream()
                 .findFirst()
                 .orElseThrow(() -> new IllegalStateException("Nothing to merge"));

--- a/core/src/main/java/org/seedstack/business/internal/domain/DomainRegistryImpl.java
+++ b/core/src/main/java/org/seedstack/business/internal/domain/DomainRegistryImpl.java
@@ -61,6 +61,11 @@ class DomainRegistryImpl implements DomainRegistry {
     }
 
     @Override
+    public <A extends AggregateRoot<I>, I> Repository<A, I> getRepository(Class<A> aggregateRootClass, Class<I> idClass, Annotation qualifier) {
+        return getInstance(getKey(getType(Repository.class, aggregateRootClass, idClass), qualifier));
+    }
+
+    @Override
     public <A extends AggregateRoot<K>, K> Repository<A, K> getRepository(Class<A> aggregateRootClass, Class<K> idClass,
             Class<? extends Annotation> qualifier) {
         return getInstance(getKey(getType(Repository.class, aggregateRootClass, idClass), qualifier));
@@ -182,6 +187,10 @@ class DomainRegistryImpl implements DomainRegistry {
     @SuppressWarnings("unchecked")
     private <T> T getInstance(Key<?> key) {
         return (T) injector.getInstance(key);
+    }
+
+    private Key<?> getKey(Type type, Annotation qualifier) {
+        return Key.get(type, qualifier);
     }
 
     private Key<?> getKey(Type type, Class<? extends Annotation> qualifier) {

--- a/specs/src/main/java/org/seedstack/business/assembler/dsl/MergeFromRepository.java
+++ b/specs/src/main/java/org/seedstack/business/assembler/dsl/MergeFromRepository.java
@@ -11,6 +11,8 @@ package org.seedstack.business.assembler.dsl;
 import org.seedstack.business.assembler.AggregateId;
 import org.seedstack.business.assembler.FactoryArgument;
 
+import java.lang.annotation.Annotation;
+
 /**
  * An element of the {@link FluentAssembler DSL} allowing to specify whether the aggregates should
  * be retrieved from a repository or created from a factory.
@@ -26,6 +28,33 @@ public interface MergeFromRepository<T> {
     MergeFromRepositoryOrFactory<T> fromRepository();
 
     /**
+     * Loads the aggregates from their repository, allowing to specify the qualifier of the repository to use.
+     * <p> It uses the {@link AggregateId} annotation on the DTO to find the aggregate IDs. </p>
+     *
+     * @param qualifier the qualifier annotation.
+     * @return the next element of the DSL.
+     */
+    MergeFromRepositoryOrFactory<T> fromRepository(Annotation qualifier);
+
+    /**
+     * Loads the aggregates from their repository, allowing to specify the qualifier of the repository to use.
+     * <p> It uses the {@link AggregateId} annotation on the DTO to find the aggregate IDs. </p>
+     *
+     * @param qualifier the string qualifier, interpreted as a {@code @Named} annotation with the corresponding value.
+     * @return the next element of the DSL.
+     */
+    MergeFromRepositoryOrFactory<T> fromRepository(String qualifier);
+
+    /**
+     * Loads the aggregates from their repository, allowing to specify the qualifier of the repository to use.
+     * <p> It uses the {@link AggregateId} annotation on the DTO to find the aggregate IDs. </p>
+     *
+     * @param qualifier the qualifier annotation class.
+     * @return the next element of the DSL.
+     */
+    MergeFromRepositoryOrFactory<T> fromRepository(Class<? extends Annotation> qualifier);
+
+    /**
      * Create the aggregates from their factory. <p> It uses the {@link FactoryArgument} annotation on
      * the DTO to find the factory method parameters. </p>
      *
@@ -33,4 +62,30 @@ public interface MergeFromRepository<T> {
      */
     T fromFactory();
 
+    /**
+     * Create the aggregates from their factory, allowing to specify the qualifier of the factory to use.
+     * <p> It uses the {@link FactoryArgument} annotation on the DTO to find the factory method parameters. </p>
+     *
+     * @param qualifier the qualifier annotation.
+     * @return the next element of the DSL.
+     */
+    T fromFactory(Annotation qualifier);
+
+    /**
+     * Create the aggregates from their factory, allowing to specify the qualifier of the factory to use.
+     * <p> It uses the {@link FactoryArgument} annotation on the DTO to find the factory method parameters. </p>
+     *
+     * @param qualifier the string qualifier, interpreted as a {@code @Named} annotation with the corresponding value.
+     * @return the next element of the DSL.
+     */
+    T fromFactory(String qualifier);
+
+    /**
+     * Create the aggregates from their factory, allowing to specify the qualifier of the factory to use.
+     * <p> It uses the {@link FactoryArgument} annotation on the DTO to find the factory method parameters. </p>
+     *
+     * @param qualifier the qualifier annotation class.
+     * @return the next element of the DSL.
+     */
+    T fromFactory(Class<? extends Annotation> qualifier);
 }

--- a/specs/src/main/java/org/seedstack/business/assembler/dsl/MergeFromRepositoryOrFactory.java
+++ b/specs/src/main/java/org/seedstack/business/assembler/dsl/MergeFromRepositoryOrFactory.java
@@ -11,6 +11,8 @@ package org.seedstack.business.assembler.dsl;
 import org.seedstack.business.assembler.FactoryArgument;
 import org.seedstack.business.domain.AggregateNotFoundException;
 
+import java.lang.annotation.Annotation;
+
 /**
  * An element of the {@link FluentAssembler DSL} allowing to specify the behavior when aggregates
  * cannot be found in the repository.
@@ -34,4 +36,34 @@ public interface MergeFromRepositoryOrFactory<T> {
      * @return the next element in the DSL.
      */
     T orFromFactory();
+
+    /**
+     * Returns the aggregates, allowing to create aggregates with its {@link org.seedstack.business.domain.Factory} when
+     * they cannot be loaded from the repository, allowing to specify the qualifier of the factory to use. It uses
+     * the {@link FactoryArgument} annotation on the DTO to find the factory method parameters.
+     *
+     * @param qualifier the qualifier annotation to choose the factory.
+     * @return the next element in the DSL.
+     */
+    T orFromFactory(Annotation qualifier);
+
+    /**
+     * Returns the aggregates, allowing to create aggregates with its {@link org.seedstack.business.domain.Factory} when
+     * they cannot be loaded from the repository, allowing to specify the qualifier of the factory to use. It uses
+     * the {@link FactoryArgument} annotation on the DTO to find the factory method parameters.
+     *
+     * @param qualifier the string qualifier to choose the factory, interpreted as a {@code @Named} annotation.
+     * @return the next element in the DSL.
+     */
+    T orFromFactory(String qualifier);
+
+    /**
+     * Returns the aggregates, allowing to create aggregates with its {@link org.seedstack.business.domain.Factory} when
+     * they cannot be loaded from the repository, allowing to specify the qualifier of the factory to use. It uses
+     * the {@link FactoryArgument} annotation on the DTO to find the factory method parameters.
+     *
+     * @param qualifier the qualifier annotation class to choose the factory.
+     * @return the next element in the DSL.
+     */
+    T orFromFactory(Class<? extends Annotation> qualifier);
 }

--- a/specs/src/main/java/org/seedstack/business/domain/DomainRegistry.java
+++ b/specs/src/main/java/org/seedstack/business/domain/DomainRegistry.java
@@ -56,6 +56,19 @@ public interface DomainRegistry {
      * @return an instance of the repository.
      */
     <A extends AggregateRoot<I>, I> Repository<A, I> getRepository(Class<A> aggregateRootClass, Class<I> idClass,
+            Annotation qualifier);
+
+    /**
+     * Get the {@link Repository} for an aggregate root and a qualifier.
+     *
+     * @param <A>                the type of the aggregate root.
+     * @param <I>                the type of the aggregate root identifier.
+     * @param aggregateRootClass the aggregate root class.
+     * @param idClass            the aggregate root identifier class.
+     * @param qualifier          the repository qualifier.
+     * @return an instance of the repository.
+     */
+    <A extends AggregateRoot<I>, I> Repository<A, I> getRepository(Class<A> aggregateRootClass, Class<I> idClass,
             Class<? extends Annotation> qualifier);
 
     /**


### PR DESCRIPTION
For now:

- Support for repo qualifiers, 
- No support for factories yet (need to refactor DtoResolver which holds the logic to create aggregates and identifiers)
- No tests

Will close #22 when done.